### PR TITLE
🛡️ Sentinel: Enforce screen protection on app launch

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -7,11 +7,13 @@ import { useEffect } from 'react';
 import 'react-native-reanimated';
 
 import { useColorScheme } from '@/hooks/useColorScheme';
+import { useScreenProtection } from '@/hooks/useScreenProtection';
 
 SplashScreen.preventAutoHideAsync();
 
 // Change font here
 export default function RootLayout() {
+  useScreenProtection();
   const colorScheme = useColorScheme();
   const [loaded] = useFonts({
     SpaceMono: require('../assets/fonts/SpaceMono-Regular.ttf'),

--- a/hooks/__tests__/useScreenProtection.test.ts
+++ b/hooks/__tests__/useScreenProtection.test.ts
@@ -1,0 +1,66 @@
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { useScreenProtection } from '../useScreenProtection';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as ScreenCapture from 'expo-screen-capture';
+
+// Mock dependencies
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+}));
+
+jest.mock('expo-screen-capture', () => ({
+  preventScreenCaptureAsync: jest.fn(),
+}));
+
+describe('useScreenProtection Hook', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('enables screen protection when setting is true', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue('true');
+
+    renderHook(() => useScreenProtection());
+
+    await waitFor(() => {
+      expect(AsyncStorage.getItem).toHaveBeenCalledWith('preventScreenshots');
+      expect(ScreenCapture.preventScreenCaptureAsync).toHaveBeenCalled();
+    });
+  });
+
+  it('does NOT enable screen protection when setting is false', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue('false');
+
+    renderHook(() => useScreenProtection());
+
+    await waitFor(() => {
+      expect(AsyncStorage.getItem).toHaveBeenCalledWith('preventScreenshots');
+      expect(ScreenCapture.preventScreenCaptureAsync).not.toHaveBeenCalled();
+    });
+  });
+
+  it('does NOT enable screen protection when setting is null', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+
+    renderHook(() => useScreenProtection());
+
+    await waitFor(() => {
+      expect(AsyncStorage.getItem).toHaveBeenCalledWith('preventScreenshots');
+      expect(ScreenCapture.preventScreenCaptureAsync).not.toHaveBeenCalled();
+    });
+  });
+
+  it('handles errors gracefully', async () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      (AsyncStorage.getItem as jest.Mock).mockRejectedValue(new Error('Storage Error'));
+
+      renderHook(() => useScreenProtection());
+
+      await waitFor(() => {
+          expect(AsyncStorage.getItem).toHaveBeenCalled();
+          expect(consoleSpy).toHaveBeenCalledWith('Failed to initialize screen protection', expect.any(Error));
+      });
+
+      consoleSpy.mockRestore();
+  });
+});

--- a/hooks/useScreenProtection.ts
+++ b/hooks/useScreenProtection.ts
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as ScreenCapture from 'expo-screen-capture';
+
+export function useScreenProtection() {
+  useEffect(() => {
+    const initProtection = async () => {
+      try {
+        const value = await AsyncStorage.getItem('preventScreenshots');
+        if (value && JSON.parse(value)) {
+          await ScreenCapture.preventScreenCaptureAsync();
+        }
+      } catch (e) {
+        console.error('Failed to initialize screen protection', e);
+      }
+    };
+    initProtection();
+  }, []);
+}


### PR DESCRIPTION
Implemented a security enhancement to enforce screen capture prevention on app launch based on user settings stored in AsyncStorage. This ensures privacy settings persist correctly across app restarts.


---
*PR created automatically by Jules for task [12440650191889324316](https://jules.google.com/task/12440650191889324316) started by @dhruvhaldar*