### PR TITLE
⚡ Bolt: Implement in-memory cache for period entries to optimize tab switching

### DIFF
--- a/app/(tabs)/history.tsx
+++ b/app/(tabs)/history.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useCallback, useRef, useMemo } from 'react';
 import { StyleSheet, View, Alert, useColorScheme, Platform, UIManager, Vibration, LayoutAnimation } from 'react-native';
-import AsyncStorage from '@react-native-async-storage/async-storage';
+// Remove direct AsyncStorage import
+// import AsyncStorage from '@react-native-async-storage/async-storage';
+import { PeriodStorage } from '@/utils/storage';
 import { ThemedText } from '@/components/ThemedText';
 import ParallaxFlatList from '@/components/ParallaxFlatList';
 import { useFocusEffect, useRouter } from 'expo-router';
@@ -31,7 +33,8 @@ export default function TabTwoScreen() {
 
   const fetchEntries = async () => {
     try {
-      const storedEntries = await AsyncStorage.getItem('periodEntries');
+      // Bolt Optimization: Use cached PeriodStorage to avoid disk reads on tab switch
+      const storedEntries = await PeriodStorage.getEntries();
       
       // Optimization: Only parse and update state if the data has actually changed
       if (storedEntries === lastFetchedEntriesRef.current) {
@@ -88,7 +91,9 @@ export default function TabTwoScreen() {
                 // But setState is sync-ish in batching.
                 // We'll update storage immediately using the computed new array
                 const newEntriesString = JSON.stringify(updatedEntries);
-                AsyncStorage.setItem('periodEntries', newEntriesString).then(() => {
+
+                // Bolt Optimization: Use PeriodStorage to save and update cache
+                PeriodStorage.saveEntries(newEntriesString).then(() => {
                   // Update the ref to prevent the next fetch (e.g. on focus) from re-rendering if it matches
                   lastFetchedEntriesRef.current = newEntriesString;
                 }).catch(err =>

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -13,6 +13,7 @@ import PredictionSummary from '@/components/PredictionSummary';
 import { StepperInput } from '@/components/StepperInput';
 import SelectionButton from '@/components/SelectionButton';
 import { NotesInput, NotesInputHandle } from '@/components/NotesInput';
+import { PeriodStorage } from '@/utils/storage';
 
 
 export default function HomeScreen() {
@@ -235,7 +236,8 @@ export default function HomeScreen() {
       let entries = [];
       
       try {
-        const existingEntries = await AsyncStorage.getItem('periodEntries');
+        // Bolt Optimization: Use cached PeriodStorage for faster access
+        const existingEntries = await PeriodStorage.getEntries();
         entries = parseSafePeriodEntries(existingEntries);
       } catch (parseError: any) {
         console.error('🚨 Error retrieving period entries:', parseError instanceof Error ? parseError.message : String(parseError));
@@ -245,7 +247,9 @@ export default function HomeScreen() {
       entries.push(entry);
   
       try {
-        await AsyncStorage.setItem('periodEntries', JSON.stringify(entries));
+        // Bolt Optimization: Use cached PeriodStorage for saving
+        await PeriodStorage.saveEntries(JSON.stringify(entries));
+
         setSelectedFlow(null); // Reset new field
         setSelectedSymptoms([]);
         notesInputRef.current?.resetNotes();

--- a/app/(tabs)/insights.tsx
+++ b/app/(tabs)/insights.tsx
@@ -6,7 +6,9 @@ import {
   useColorScheme, 
   Dimensions 
 } from 'react-native';
-import AsyncStorage from '@react-native-async-storage/async-storage';
+// Remove direct AsyncStorage import
+// import AsyncStorage from '@react-native-async-storage/async-storage';
+import { PeriodStorage } from '@/utils/storage';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
 import ParallaxScrollView from '@/components/ParallaxScrollView';
@@ -52,7 +54,8 @@ export default function InsightsScreen() {
 
   const fetchEntries = async () => {
     try {
-      const storedEntries = await AsyncStorage.getItem('periodEntries');
+      // Bolt Optimization: Use cached PeriodStorage to avoid disk reads on tab switch
+      const storedEntries = await PeriodStorage.getEntries();
 
       // Optimization: Only parse and update state if the data has actually changed
       if (storedEntries === lastFetchedEntriesRef.current) {

--- a/utils/__tests__/storage.test.ts
+++ b/utils/__tests__/storage.test.ts
@@ -1,0 +1,50 @@
+import { PeriodStorage } from '../storage';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+// Mock AsyncStorage
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+}));
+
+describe('PeriodStorage', () => {
+  beforeEach(() => {
+    PeriodStorage.clearCache();
+    jest.clearAllMocks();
+  });
+
+  it('getEntries calls AsyncStorage on first call', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue('test-data');
+
+    const result = await PeriodStorage.getEntries();
+
+    expect(result).toBe('test-data');
+    expect(AsyncStorage.getItem).toHaveBeenCalledWith('periodEntries');
+    expect(AsyncStorage.getItem).toHaveBeenCalledTimes(1);
+  });
+
+  it('getEntries returns cached value on second call without hitting AsyncStorage', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue('test-data');
+
+    // First call populates cache
+    await PeriodStorage.getEntries();
+    expect(AsyncStorage.getItem).toHaveBeenCalledTimes(1);
+
+    // Second call should use cache
+    const result = await PeriodStorage.getEntries();
+    expect(result).toBe('test-data');
+    expect(AsyncStorage.getItem).toHaveBeenCalledTimes(1); // Call count remains 1
+  });
+
+  it('saveEntries updates cache and calls AsyncStorage', async () => {
+    const newData = 'new-data';
+    await PeriodStorage.saveEntries(newData);
+
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith('periodEntries', newData);
+
+    // Verify cache is updated by calling getEntries
+    const result = await PeriodStorage.getEntries();
+    expect(result).toBe(newData);
+    expect(AsyncStorage.getItem).not.toHaveBeenCalled(); // Should not call getItem if cache is hit
+  });
+});

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -1,0 +1,40 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+/**
+ * PeriodStorage
+ * A simple layer over AsyncStorage with in-memory caching to prevent
+ * unnecessary disk reads and bridge crossing on frequent tab switches.
+ */
+
+let cachedEntries: string | null = null;
+
+export const PeriodStorage = {
+  /**
+   * Retrieves period entries from cache or AsyncStorage.
+   * If available in cache, returns immediately without async bridge call.
+   */
+  async getEntries(): Promise<string | null> {
+    if (cachedEntries !== null) {
+      return cachedEntries;
+    }
+    const entries = await AsyncStorage.getItem('periodEntries');
+    cachedEntries = entries;
+    return entries;
+  },
+
+  /**
+   * Saves period entries to AsyncStorage and updates the cache.
+   * Ensures subsequent reads are consistent.
+   */
+  async saveEntries(entriesString: string): Promise<void> {
+    cachedEntries = entriesString;
+    await AsyncStorage.setItem('periodEntries', entriesString);
+  },
+
+  /**
+   * Clears the cache. Useful for testing or full reset.
+   */
+  clearCache() {
+    cachedEntries = null;
+  }
+};


### PR DESCRIPTION
💡 **What:**
Implemented a `PeriodStorage` utility in `utils/storage.ts` that wraps `AsyncStorage` with an in-memory cache for `periodEntries`.
Updated `HomeScreen` (write), `HistoryScreen` (read/delete), and `InsightsScreen` (read) to use this service.

🎯 **Why:**
`periodEntries` is the core data accessed on nearly every tab. Previously, `AsyncStorage.getItem` was called on every screen focus. While `HistoryScreen` and `InsightsScreen` had logic to skip parsing if the *string* hadn't changed, they still incurred the cost of:
1.  Crossing the React Native Bridge (asynchronous).
2.  Reading from disk/database.
3.  Allocating the string in memory.

By caching the raw string in memory, subsequent reads are instant and synchronous (from the JS thread's perspective), significantly improving the responsiveness of tab switching.

📊 **Impact:**
- Eliminates redundant `AsyncStorage.getItem` calls on tab focus for cached data.
- Reduces bridge traffic.
- Ensures data consistency across tabs via a centralized service.

🔬 **Measurement:**
- Verified via unit tests in `utils/__tests__/storage.test.ts`.
- Verified logic in `history.tsx` and `insights.tsx` to ensure `lastFetchedEntriesRef` optimization still works with the cached value.

---
*PR created automatically by Jules for task [855763520588100418](https://jules.google.com/task/855763520588100418) started by @dhruvhaldar*