### PR TITLE
🛡️ Sentinel: [CRITICAL] Disable Android Backup to protect unencrypted health data

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -27,3 +27,8 @@
 **Vulnerability:** The app read the entire backup file into memory using `FileSystem.readAsStringAsync` without checking its size, allowing attackers (or accidental users) to crash the app (OOM) with large files.
 **Learning:** `FileSystem.readAsStringAsync` is dangerous for untrusted files without size checks. Always check `fileInfo.size` first.
 **Prevention:** Enforce `MAX_BACKUP_FILE_SIZE` check using `FileSystem.getInfoAsync` before reading file content.
+
+## 2026-02-12 - Insecure Android Backup of Health Data
+**Vulnerability:** The Android configuration allowed automatic OS backups (`android:allowBackup="true"`), enabling extraction of unencrypted sensitive health data from `AsyncStorage` via ADB or cloud backups.
+**Learning:** Default framework configurations (like React Native/Expo defaults) often prioritize convenience over security. For health/finance apps, sticking to defaults for data backup is a privacy risk.
+**Prevention:** Explicitly disable backup (`android:allowBackup="false"`) or use `android:fullBackupContent` to exclude sensitive databases if `SecureStore` is not used.

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -11,7 +11,7 @@
       <data android:scheme="https"/>
     </intent>
   </queries>
-  <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:allowBackup="true" android:theme="@style/AppTheme" android:supportsRtl="true">
+  <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:allowBackup="false" android:theme="@style/AppTheme" android:supportsRtl="true">
     <meta-data android:name="expo.modules.updates.ENABLED" android:value="true"/>
     <meta-data android:name="expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH" android:value="ALWAYS"/>
     <meta-data android:name="expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS" android:value="0"/>

--- a/app.json
+++ b/app.json
@@ -17,7 +17,8 @@
         "foregroundImage": "./assets/images/adaptive-icon.png",
         "backgroundColor": "#ee2d60"
       },
-      "package": "com.anonymous.LunaBloom"
+      "package": "com.anonymous.LunaBloom",
+      "allowBackup": false
     },
     "web": {
       "bundler": "metro",


### PR DESCRIPTION
**Security Fix: Disable Android Backup**

**Vulnerability:**
The application stores sensitive health data (period logs, symptoms) in `AsyncStorage`, which relies on the underlying OS storage. On Android, `AsyncStorage` data is stored in a plaintext SQLite database. The default Android configuration (`allowBackup="true"`) allows this data to be extracted via ADB backup or automatically backed up to Google Drive, potentially exposing private health information (PHI).

**Fix:**
- Updated `app.json` to set `android.allowBackup` to `false`. This ensures that future builds (via `expo prebuild`) generate the correct manifest configuration.
- Manually updated `android/app/src/main/AndroidManifest.xml` to set `android:allowBackup="false"` to immediately secure the codebase for native builds.
- Added a Sentinel journal entry in `.jules/sentinel.md` to document the risk and the decision.

**Verification:**
- Verified `app.json` contains `"allowBackup": false`.
- Verified `AndroidManifest.xml` contains `android:allowBackup="false"`.
- Ran `pnpm test` to ensure no regressions in existing tests (passed, ignoring unrelated snapshot whitespace noise).

---
*PR created automatically by Jules for task [14556682046334567647](https://jules.google.com/task/14556682046334567647) started by @dhruvhaldar*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled Android app backup functionality to prevent unauthorized access to sensitive user data stored on devices.

* **Documentation**
  * Added security advisory documenting backup vulnerabilities and mitigation strategies for sensitive data protection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->