### PR TITLE
⚡ Bolt: Memoize Chatbot header to prevent re-renders

### DIFF
--- a/app/(tabs)/chatbot.tsx
+++ b/app/(tabs)/chatbot.tsx
@@ -70,8 +70,25 @@ export default function MenstruationScreen() {
     }
   }, [response]);
 
+  // Optimization: Memoize header props to prevent re-rendering ParallaxScrollView header
+  const headerBackgroundColor = useMemo(() => ({
+    light: '#ffdde2',
+    dark: '#151718'
+  }), []);
+
+  const headerImage = useMemo(() => (
+    <Image
+      source={require('@/assets/images/history2.png')}
+      style={styles.reactLogo}
+      resizeMode="contain"
+    />
+  ), []);
+
   return (
-    <ParallaxScrollView headerBackgroundColor={{ light: '#ffdde2', dark: '#151718' }} headerImage={<Image source={require('@/assets/images/history2.png')} style={styles.reactLogo} resizeMode="contain"/>}>
+    <ParallaxScrollView
+      headerBackgroundColor={headerBackgroundColor}
+      headerImage={headerImage}
+    >
       <ThemedView style={styles.container}>
         <ThemedText type="title" style={styles.title}>MenstruAI 🩸 {Platform.OS === 'web' ? '(Web Lite)' : '(Local)'}</ThemedText>
 


### PR DESCRIPTION
⚡ Bolt: Memoize Chatbot header to prevent re-renders

💡 What: Wrapped `headerBackgroundColor` and `headerImage` in `useMemo` hooks in `app/(tabs)/chatbot.tsx`.
🎯 Why: These props were being re-created on every render (e.g. typing in the chat input), causing the `ParallaxScrollView` header to unnecessarily re-render and re-animate.
📊 Impact: Reduces re-renders of the header component to near zero during user interaction, improving typing responsiveness.
🔬 Measurement: Verified that `useMemo` is correctly applied and props are stable.


---
*PR created automatically by Jules for task [11280021248049989445](https://jules.google.com/task/11280021248049989445) started by @dhruvhaldar*