### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS bypass via input obfuscation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -32,3 +32,8 @@
 **Vulnerability:** The Android configuration allowed automatic OS backups (`android:allowBackup="true"`), enabling extraction of unencrypted sensitive health data from `AsyncStorage` via ADB or cloud backups.
 **Learning:** Default framework configurations (like React Native/Expo defaults) often prioritize convenience over security. For health/finance apps, sticking to defaults for data backup is a privacy risk.
 **Prevention:** Explicitly disable backup (`android:allowBackup="false"`) or use `android:fullBackupContent` to exclude sensitive databases if `SecureStore` is not used.
+
+## 2026-02-18 - XSS Bypass via Input Obfuscation
+**Vulnerability:** The input validation used a "denylist" of regex patterns to detect malicious content (e.g., `javascript:`) but failed to normalize the input first. Attackers could bypass detection using whitespace or control characters (e.g., `j a v a s c r i p t :`).
+**Learning:** Denylists are inherently brittle. Regex checks against raw user input are easily bypassed by obfuscation unless the input is first canonicalized/normalized to a standard form.
+**Prevention:** Always normalize input (strip whitespace, control characters, unescape entities) before applying security filters. Better yet, use "allowlists" where possible or established sanitization libraries instead of custom regex.

--- a/utils/__tests__/validation.test.ts
+++ b/utils/__tests__/validation.test.ts
@@ -60,6 +60,15 @@ describe('Validation Utils', () => {
       expect(containsSuspiciousPatterns('<img src=x onerror=alert(1)>')).toBe(true);
     });
 
+    it('detects obfuscated javascript: URI (whitespace)', () => {
+      expect(containsSuspiciousPatterns('j a v a s c r i p t : alert(1)')).toBe(true);
+      expect(containsSuspiciousPatterns('java script:alert(1)')).toBe(true);
+    });
+
+    it('detects obfuscated script tags', () => {
+      expect(containsSuspiciousPatterns('< s c r i p t > alert(1) < / s c r i p t >')).toBe(true);
+    });
+
     it('allows safe text', () => {
       expect(containsSuspiciousPatterns('Hello World')).toBe(false);
     });

--- a/utils/validation.ts
+++ b/utils/validation.ts
@@ -92,7 +92,15 @@ const SUSPICIOUS_PATTERNS = [
  * @returns True if the text contains suspicious patterns.
  */
 export const containsSuspiciousPatterns = (text: string): boolean => {
-    return SUSPICIOUS_PATTERNS.some(pattern => pattern.test(text));
+    // Check original text first (fast path)
+    if (SUSPICIOUS_PATTERNS.some(pattern => pattern.test(text))) {
+        return true;
+    }
+
+    // Normalization: strip whitespace and control characters to prevent obfuscation
+    // e.g. "j a v a s c r i p t :" -> "javascript:"
+    const normalizedText = text.replace(/[\s\x00-\x1F]/g, '');
+    return SUSPICIOUS_PATTERNS.some(pattern => pattern.test(normalizedText));
 };
 
 /**


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix XSS bypass via input obfuscation

🚨 **Severity:** HIGH
💡 **Vulnerability:** Input validation relied on "denylist" regexes without normalization, allowing attackers to bypass checks by inserting whitespace or control characters into dangerous payloads (e.g., `j a v a s c r i p t :`).
🎯 **Impact:** XSS attacks could be executed against users if malicious input (e.g. notes) is rendered in a web context or insecurely handled view.
🔧 **Fix:** Updated `containsSuspiciousPatterns` in `utils/validation.ts` to strip whitespace and control characters before checking against the blacklist. The original check is kept as a fast path.
✅ **Verification:** Added new test cases in `utils/__tests__/validation.test.ts` to confirm that obfuscated payloads are now detected as suspicious. Ran `pnpm test` to ensure all tests pass.

---
*PR created automatically by Jules for task [655666136513430072](https://jules.google.com/task/655666136513430072) started by @dhruvhaldar*