### PR TITLE
⚡ Bolt: optimize PredictionSummary calculation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -29,3 +29,7 @@
 ## 2026-05-22 - Fragment Props Stability
 **Learning:** Passing an inline Fragment (e.g. `<>...</>`) or an inline element as a prop (like `ListHeaderComponent`) creates a new object reference on every render. For components like `FlatList`, this forces the header to unmount and remount, causing potential state loss and animation glitches.
 **Action:** Memoize the component passed to `ListHeaderComponent` (or similar props) using `useMemo` to ensure referential stability across re-renders.
+
+## 2026-01-30 - [Parallax Components Re-render Pattern]
+**Learning:** `ParallaxScrollView` and similar wrapper components re-render fully on every parent update because `children` are passed as new JSX elements. Even if internal headers are memoized, the scroll view and content wrapper re-render.
+**Action:** When using `ParallaxScrollView`, ensure heavy child components are memoized individually, as the wrapper itself provides no memoization for children.

--- a/components/PredictionSummary.tsx
+++ b/components/PredictionSummary.tsx
@@ -25,6 +25,32 @@ const PredictionSummary = React.memo(function PredictionSummary({
   // Further Optimization: Split sections into useMemo blocks so that changing periodDuration (which happens frequently on typing)
   // doesn't re-render the ovulation section.
 
+  // Bolt Optimization: Calculate days remaining separately to avoid re-calculation when periodDuration changes
+  const daysRemainingInfo = useMemo(() => {
+    if (predictedPeriods.length === 0) return { text: '', label: '' };
+
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const target = new Date(predictedPeriods[0]);
+    target.setHours(0, 0, 0, 0);
+    const diffTime = target.getTime() - today.getTime();
+    const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+
+    let text = '';
+    let label = '';
+    if (diffDays === 0) {
+      text = ' (Today)';
+      label = ', starting today';
+    } else if (diffDays === 1) {
+      text = ' (Tomorrow)';
+      label = ', starting tomorrow';
+    } else if (diffDays > 1) {
+      text = ` (in ${diffDays} days)`;
+      label = `, in ${diffDays} days`;
+    }
+    return { text, label };
+  }, [predictedPeriods]);
+
   const periodsSection = useMemo(() => (
     <ThemedView style={styles.section}>
       <ThemedText type="subtitle" style={{ color: predictedHeadingColor, marginBottom: 10, marginTop: 15 }}>
@@ -35,28 +61,9 @@ const PredictionSummary = React.memo(function PredictionSummary({
         const periodEndDate = new Date(date);
         periodEndDate.setDate(periodEndDate.getDate() + Number(periodDuration) - 1);
 
-        // Calculate days remaining for the next period
-        let daysRemainingText = '';
-        let daysRemainingLabel = '';
-        if (index === 0) {
-          const today = new Date();
-          today.setHours(0, 0, 0, 0);
-          const target = new Date(date);
-          target.setHours(0, 0, 0, 0);
-          const diffTime = target.getTime() - today.getTime();
-          const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
-
-          if (diffDays === 0) {
-            daysRemainingText = ' (Today)';
-            daysRemainingLabel = ', starting today';
-          } else if (diffDays === 1) {
-            daysRemainingText = ' (Tomorrow)';
-            daysRemainingLabel = ', starting tomorrow';
-          } else if (diffDays > 1) {
-            daysRemainingText = ` (in ${diffDays} days)`;
-            daysRemainingLabel = `, in ${diffDays} days`;
-          }
-        }
+        // Get pre-calculated days remaining for the first period
+        const { text: daysRemainingText, label: daysRemainingLabel } =
+          index === 0 ? daysRemainingInfo : { text: '', label: '' };
 
         return (
           <ThemedView
@@ -85,7 +92,7 @@ const PredictionSummary = React.memo(function PredictionSummary({
         );
       })}
     </ThemedView>
-  ), [predictedPeriods, periodDuration, predictedHeadingColor, textColor]);
+  ), [predictedPeriods, periodDuration, predictedHeadingColor, textColor, daysRemainingInfo]);
 
   const ovulationSection = useMemo(() => (
     <ThemedView style={styles.section}>


### PR DESCRIPTION
⚡ Bolt: Optimized PredictionSummary component

💡 What: Extracted 'days remaining' calculation into a separate useMemo hook in `components/PredictionSummary.tsx`.
🎯 Why: The component was recalculating the 'days remaining' label (involving `new Date()` allocations) on every render, even when only `periodDuration` changed. Since 'days remaining' depends only on `predictedPeriods`, it should not be recomputed when the user interacts with the Period Duration stepper.
📊 Impact: Reduces unnecessary Date object creation and math operations during high-frequency updates (typing/stepping duration).
🔬 Measurement: Verified with unit tests (`pnpm test components/__tests__/PredictionSummary-test.tsx`) and snapshot updates.

---
*PR created automatically by Jules for task [9465844697422102853](https://jules.google.com/task/9465844697422102853) started by @dhruvhaldar*