### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS filter bypass via whitespace obfuscation

### DIFF
--- a/utils/__tests__/validation.test.ts
+++ b/utils/__tests__/validation.test.ts
@@ -63,6 +63,12 @@ describe('Validation Utils', () => {
     it('allows safe text', () => {
       expect(containsSuspiciousPatterns('Hello World')).toBe(false);
     });
+
+    // Vulnerability reproduction
+    it('detects obfuscated javascript: URI', () => {
+        expect(containsSuspiciousPatterns('java script:alert(1)')).toBe(true);
+        expect(containsSuspiciousPatterns('javascript :alert(1)')).toBe(true);
+    });
   });
 
   describe('validateInputLength', () => {

--- a/utils/validation.ts
+++ b/utils/validation.ts
@@ -61,15 +61,19 @@ export const sanitizePromptInput = (text: string): string => {
   return sanitized;
 };
 
+const DANGEROUS_PROTOCOLS = [
+    /javascript:/im,
+    /vbscript:/im,
+    /data:text\/html/im,
+];
+
 // Defense-in-depth: Check for common XSS vectors and malicious patterns.
 // Note: This is not a complete XSS filter but catches common attempts.
 // Optimization: Define patterns once to avoid recreation on every validation call.
 // Global flag 'g' is removed to keep regexes stateless for shared use.
 const SUSPICIOUS_PATTERNS = [
     /<script\b[^>]*>([\s\S]*?)<\/script>/im,
-    /javascript:/im,
-    /vbscript:/im,
-    /data:text\/html/im,
+    ...DANGEROUS_PROTOCOLS,
     // Common dangerous event handlers (using word boundaries to avoid false positives)
     /\bonload\s*=/im,
     /\bonerror\s*=/im,
@@ -92,7 +96,17 @@ const SUSPICIOUS_PATTERNS = [
  * @returns True if the text contains suspicious patterns.
  */
 export const containsSuspiciousPatterns = (text: string): boolean => {
-    return SUSPICIOUS_PATTERNS.some(pattern => pattern.test(text));
+    // 1. Check original text against all patterns
+    if (SUSPICIOUS_PATTERNS.some(pattern => pattern.test(text))) {
+        return true;
+    }
+
+    // 2. Normalize: remove all whitespace and control characters
+    const normalized = text.replace(/[\s\x00-\x1F]/g, '');
+
+    // 3. Check for dangerous protocols in normalized text to detect obfuscation
+    // (e.g. "j a v a s c r i p t :")
+    return DANGEROUS_PROTOCOLS.some(pattern => pattern.test(normalized));
 };
 
 /**


### PR DESCRIPTION
This PR addresses a security vulnerability where attackers could bypass the XSS filter by using whitespace or control characters to obfuscate dangerous protocols (e.g., `j a v a s c r i p t :`).

**Changes:**
- `utils/validation.ts`:
    - Extracted dangerous protocol patterns into `DANGEROUS_PROTOCOLS`.
    - Added a normalization step that strips all whitespace and control characters (`/[\s\x00-\x1F]/g`).
    - Added a check against `DANGEROUS_PROTOCOLS` using the normalized text.
- `utils/__tests__/validation.test.ts`:
    - Added test cases to verify detection of obfuscated `javascript:` URIs.

**Verification:**
- Run `pnpm test utils/__tests__/validation.test.ts` to verify the fix and ensure no regressions.


---
*PR created automatically by Jules for task [4272156596711504686](https://jules.google.com/task/4272156596711504686) started by @dhruvhaldar*