### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix PHI consistency in Settings

### DIFF
--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { StyleSheet, View, Alert, useColorScheme, TouchableOpacity, Image } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { PeriodStorage } from '@/utils/storage';
 import { IconSymbol } from '@/components/ui/IconSymbol';
 import * as DocumentPicker from 'expo-document-picker';
 import * as FileSystem from 'expo-file-system';
@@ -103,7 +104,7 @@ export default function SettingsScreen() {
 
     const backupData = async () => {
             try {
-              const existingEntries = await AsyncStorage.getItem('periodEntries');
+              const existingEntries = await PeriodStorage.getEntries();
               if (!existingEntries) {
                 Alert.alert('No data to backup', 'Please log at least one entry.');
                 return;
@@ -263,7 +264,7 @@ export default function SettingsScreen() {
             }
 
             // Store the entries in AsyncStorage
-            await AsyncStorage.setItem('periodEntries', JSON.stringify(sanitizedEntries));
+            await PeriodStorage.saveEntries(JSON.stringify(sanitizedEntries));
             
             Alert.alert(
                 '✅ Restore Successful',


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Inconsistent PHI State
🎯 Impact: Restoring a backup or overwriting data in Settings used direct AsyncStorage calls, bypassing the in-memory PeriodStorage cache. This could lead to the application displaying stale (potentially sensitive or deleted) health data until a full app restart.
🔧 Fix: Updated `app/(tabs)/settings.tsx` to use `PeriodStorage.getEntries()` and `PeriodStorage.saveEntries()` for backup and restore operations.
✅ Verification: Verified via `utils/__tests__/storage.test.ts` (passed) and code review of `settings.tsx` imports and usage. Confirmed PeriodStorage interface matches usage.

---
*PR created automatically by Jules for task [13145758378878040559](https://jules.google.com/task/13145758378878040559) started by @dhruvhaldar*