### PR TITLE
🎨 Palette: Improve settings toggle accessibility and touch targets

### DIFF
--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useMemo } from 'react';
-import { StyleSheet, View, Alert, useColorScheme, TouchableOpacity, Image } from 'react-native';
+import { StyleSheet, View, Alert, useColorScheme, TouchableOpacity, Image, Platform } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as Haptics from 'expo-haptics';
 import { IconSymbol } from '@/components/ui/IconSymbol';
 import * as DocumentPicker from 'expo-document-picker';
 import * as FileSystem from 'expo-file-system';
@@ -304,23 +305,53 @@ export default function SettingsScreen() {
                 <View style={styles.section}>
                     <ThemedText style={[styles.sectionTitle, { color: textColor }]}>Other Settings</ThemedText>
                     
-                    <View style={styles.settingRow}>
+                    <TouchableOpacity
+                        style={styles.settingRow}
+                        onPress={() => {
+                            if (Platform.OS !== 'web') {
+                                Haptics.selectionAsync();
+                            }
+                            handleLutealPhaseToggle(!lutealPhase);
+                        }}
+                        activeOpacity={0.7}
+                        accessibilityRole="switch"
+                        accessibilityState={{ checked: lutealPhase }}
+                        accessibilityLabel="Luteal Phase Calculation"
+                    >
                         <ThemedText style={[styles.settingText, { color: textColor }]}>Luteal Phase Calculation</ThemedText>
-                        <Switch
-                            value={lutealPhase}
-                            onValueChange={handleLutealPhaseToggle}
-                            accessibilityLabel="Luteal Phase Calculation"
-                        />
-                    </View>
+                        <View pointerEvents="none">
+                            <Switch
+                                value={lutealPhase}
+                                onValueChange={() => {}}
+                                accessibilityLabel="Luteal Phase Calculation"
+                                accessible={false}
+                            />
+                        </View>
+                    </TouchableOpacity>
 
-                    <View style={styles.settingRow}>
+                    <TouchableOpacity
+                        style={styles.settingRow}
+                        onPress={() => {
+                            if (Platform.OS !== 'web') {
+                                Haptics.selectionAsync();
+                            }
+                            handleScreenshotToggle(!preventScreenshots);
+                        }}
+                        activeOpacity={0.7}
+                        accessibilityRole="switch"
+                        accessibilityState={{ checked: preventScreenshots }}
+                        accessibilityLabel="Prevent Screenshots"
+                    >
                         <ThemedText style={[styles.settingText, { color: textColor }]}>Prevent Screenshots</ThemedText>
-                        <Switch
-                            value={preventScreenshots}
-                            onValueChange={handleScreenshotToggle}
-                            accessibilityLabel="Prevent Screenshots"
-                        />
-                    </View>
+                        <View pointerEvents="none">
+                            <Switch
+                                value={preventScreenshots}
+                                onValueChange={() => {}}
+                                accessibilityLabel="Prevent Screenshots"
+                                accessible={false}
+                            />
+                        </View>
+                    </TouchableOpacity>
                 </View>
 
                 {/* Backup Section */}

--- a/components/ui/Switch.tsx
+++ b/components/ui/Switch.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useRef } from 'react';
-import { Animated, TouchableOpacity, StyleSheet, Platform, ColorValue } from 'react-native';
+import { Animated, TouchableOpacity, StyleSheet, Platform, ColorValue, TouchableOpacityProps } from 'react-native';
 import * as Haptics from 'expo-haptics';
 import { IconSymbol } from '@/components/ui/IconSymbol';
 
-interface SwitchProps {
+interface SwitchProps extends Omit<TouchableOpacityProps, 'value' | 'onValueChange'> {
   value: boolean;
   onValueChange: (value: boolean) => void;
   accessibilityLabel: string;
@@ -17,6 +17,7 @@ export function Switch({
   accessibilityLabel,
   activeColor = '#457B9D',
   inactiveColor = '#3f3f3f',
+  ...props
 }: SwitchProps) {
   const animatedValue = useRef(new Animated.Value(value ? 1 : 0)).current;
 
@@ -56,6 +57,7 @@ export function Switch({
       accessibilityRole="switch"
       accessibilityState={{ checked: value }}
       accessibilityLabel={accessibilityLabel}
+      {...props}
     >
       <Animated.View style={[styles.container, { backgroundColor }]}>
         <Animated.View style={[styles.thumb, { transform: [{ translateX }] }]}>


### PR DESCRIPTION
💡 What:
- Refactored settings rows in `app/(tabs)/settings.tsx` to be fully tappable (TouchableOpacity).
- Modified `components/ui/Switch.tsx` to accept standard `TouchableOpacityProps` (allowing overrides).
- Added haptic feedback (`Haptics.selectionAsync`) to row taps.

🎯 Why:
- Improves usability by increasing the touch target size for settings toggles.
- Ensures consistency with platform conventions (toggling by tapping the label).
- Provides tactile feedback.

♿ Accessibility:
- Wrapped `Switch` components are now hidden from accessibility (`accessible={false}`, `pointerEvents="none"`) to avoid duplicate controls.
- The parent row `TouchableOpacity` now carries the `accessibilityRole="switch"` and `accessibilityState`, providing a single, clear interactive element for screen readers.

---
*PR created automatically by Jules for task [77390668876608467](https://jules.google.com/task/77390668876608467) started by @dhruvhaldar*