### PR TITLE
🛡️ Sentinel: [HIGH] Prevent XSS in ExternalLink via protocol validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -32,3 +32,8 @@
 **Vulnerability:** The Android configuration allowed automatic OS backups (`android:allowBackup="true"`), enabling extraction of unencrypted sensitive health data from `AsyncStorage` via ADB or cloud backups.
 **Learning:** Default framework configurations (like React Native/Expo defaults) often prioritize convenience over security. For health/finance apps, sticking to defaults for data backup is a privacy risk.
 **Prevention:** Explicitly disable backup (`android:allowBackup="false"`) or use `android:fullBackupContent` to exclude sensitive databases if `SecureStore` is not used.
+
+## 2026-02-15 - XSS Risk in ExternalLink
+**Vulnerability:** The `ExternalLink` component blindly passed the `href` prop to `expo-router`'s `Link` component. On the web, this renders an `<a>` tag, allowing execution of `javascript:` URIs if an attacker can control the link target (DOM-based XSS).
+**Learning:** Wrapper components around navigation primitives often inherit their insecurities. Just because a component is named `ExternalLink` doesn't mean it only handles safe external URLs.
+**Prevention:** Explicitly validate protocols in link components. Allow only `http` and `https` schemes for "external" web links, and block or sanitize anything else.

--- a/components/ExternalLink.tsx
+++ b/components/ExternalLink.tsx
@@ -6,6 +6,17 @@ import { Platform } from 'react-native';
 type Props = Omit<ComponentProps<typeof Link>, 'href'> & { href: string };
 
 export function ExternalLink({ href, ...rest }: Props) {
+  // Security: Validate protocol to prevent XSS (e.g. javascript: schemes)
+  const isSafe = /^https?:\/\//i.test(href);
+
+  if (!isSafe) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn(`Blocked potentially unsafe ExternalLink href: ${href}`);
+    }
+    // Render children safely without link wrapper
+    return <>{rest.children}</>;
+  }
+
   return (
     <Link
       target="_blank"

--- a/components/__tests__/ExternalLink-test.tsx
+++ b/components/__tests__/ExternalLink-test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { render } from '@testing-library/react-native';
+import { ExternalLink } from '../ExternalLink';
+import { Link } from 'expo-router';
+
+// Mock expo-router
+jest.mock('expo-router', () => ({
+  Link: jest.fn(({ children }) => <>{children}</>),
+}));
+
+// Mock expo-web-browser
+jest.mock('expo-web-browser', () => ({
+  openBrowserAsync: jest.fn(),
+}));
+
+describe('ExternalLink Security', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('blocks dangerous javascript: href and renders children only', () => {
+    const dangerousHref = 'javascript:alert(1)';
+    const childText = 'Click me';
+
+    const { getByText } = render(
+      <ExternalLink href={dangerousHref}>
+        <Text>{childText}</Text>
+      </ExternalLink>
+    );
+
+    // Verify Link was NOT used
+    expect(Link).not.toHaveBeenCalled();
+
+    // Verify children are still rendered
+    expect(getByText(childText)).toBeTruthy();
+  });
+
+  it('passes valid https: href to Link component', () => {
+    const validHref = 'https://example.com';
+    const childText = 'Valid Link';
+    render(
+      <ExternalLink href={validHref}>
+        <Text>{childText}</Text>
+      </ExternalLink>
+    );
+
+    expect(Link).toHaveBeenCalledWith(
+      expect.objectContaining({ href: validHref }),
+      expect.anything()
+    );
+  });
+});


### PR DESCRIPTION
Hardens the ExternalLink component to allow only http/https protocols, preventing potential XSS attacks via javascript: URIs. Includes regression tests.

---
*PR created automatically by Jules for task [12182337963690274509](https://jules.google.com/task/12182337963690274509) started by @dhruvhaldar*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a critical security vulnerability in external link handling that could allow execution of malicious scripts via specially crafted URLs. The app now validates all external links to ensure they only use secure protocols (http/https) before navigation. Unsafe links display their content without enabling navigation, preventing harmful URLs from being accessed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->