### PR TITLE
UX: Make settings rows tappable and accessible

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2025-10-28 - Efficient Stepper Inputs
 **Learning:** Default stepper inputs require repetitive tapping for large changes and manual deletion for replacing values, frustrating power users.
 **Action:** Enable `selectTextOnFocus` on the input for one-tap replacement and implement `onLongPress` timers for rapid increment/decrement, significantly reducing interaction cost.
+
+## 2025-10-29 - Tappable Settings Rows
+**Learning:** Small toggle switches have poor touch targets, frustrating users and failing accessibility guidelines for motor impairments.
+**Action:** Wrap the entire settings row (label + switch) in a `TouchableOpacity`. Apply `accessibilityRole="switch"` to the wrapper and hide the internal switch from accessibility (`accessible={false}`, `pointerEvents="none"`), creating a large, single touch target that behaves natively.

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -304,23 +304,41 @@ export default function SettingsScreen() {
                 <View style={styles.section}>
                     <ThemedText style={[styles.sectionTitle, { color: textColor }]}>Other Settings</ThemedText>
                     
-                    <View style={styles.settingRow}>
+                    <TouchableOpacity
+                        style={styles.settingRow}
+                        onPress={() => handleLutealPhaseToggle(!lutealPhase)}
+                        activeOpacity={0.7}
+                        accessibilityRole="switch"
+                        accessibilityState={{ checked: lutealPhase }}
+                        accessibilityLabel="Luteal Phase Calculation"
+                    >
                         <ThemedText style={[styles.settingText, { color: textColor }]}>Luteal Phase Calculation</ThemedText>
                         <Switch
                             value={lutealPhase}
                             onValueChange={handleLutealPhaseToggle}
                             accessibilityLabel="Luteal Phase Calculation"
+                            accessible={false}
+                            pointerEvents="none"
                         />
-                    </View>
+                    </TouchableOpacity>
 
-                    <View style={styles.settingRow}>
+                    <TouchableOpacity
+                        style={styles.settingRow}
+                        onPress={() => handleScreenshotToggle(!preventScreenshots)}
+                        activeOpacity={0.7}
+                        accessibilityRole="switch"
+                        accessibilityState={{ checked: preventScreenshots }}
+                        accessibilityLabel="Prevent Screenshots"
+                    >
                         <ThemedText style={[styles.settingText, { color: textColor }]}>Prevent Screenshots</ThemedText>
                         <Switch
                             value={preventScreenshots}
                             onValueChange={handleScreenshotToggle}
                             accessibilityLabel="Prevent Screenshots"
+                            accessible={false}
+                            pointerEvents="none"
                         />
-                    </View>
+                    </TouchableOpacity>
                 </View>
 
                 {/* Backup Section */}

--- a/components/ui/Switch.tsx
+++ b/components/ui/Switch.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useRef } from 'react';
-import { Animated, TouchableOpacity, StyleSheet, Platform, ColorValue } from 'react-native';
+import { Animated, TouchableOpacity, StyleSheet, Platform, ColorValue, TouchableOpacityProps } from 'react-native';
 import * as Haptics from 'expo-haptics';
 import { IconSymbol } from '@/components/ui/IconSymbol';
 
-interface SwitchProps {
+interface SwitchProps extends Omit<TouchableOpacityProps, 'value' | 'style' | 'onPress'> {
   value: boolean;
   onValueChange: (value: boolean) => void;
   accessibilityLabel: string;
@@ -17,6 +17,7 @@ export function Switch({
   accessibilityLabel,
   activeColor = '#457B9D',
   inactiveColor = '#3f3f3f',
+  ...props
 }: SwitchProps) {
   const animatedValue = useRef(new Animated.Value(value ? 1 : 0)).current;
 
@@ -56,6 +57,7 @@ export function Switch({
       accessibilityRole="switch"
       accessibilityState={{ checked: value }}
       accessibilityLabel={accessibilityLabel}
+      {...props}
     >
       <Animated.View style={[styles.container, { backgroundColor }]}>
         <Animated.View style={[styles.thumb, { transform: [{ translateX }] }]}>


### PR DESCRIPTION
Improved the UX of the Settings screen by making the entire row for "Luteal Phase Calculation" and "Prevent Screenshots" tappable. This increases the touch target size significantly. Also ensured the rows are accessible by treating them as switch roles and silencing the internal switch component to avoid confusion. Updated `Switch` component to support this pattern. Verified with tests and Playwright.

---
*PR created automatically by Jules for task [60437908584976493](https://jules.google.com/task/60437908584976493) started by @dhruvhaldar*