### PR TITLE
🛡️ Sentinel: [HIGH] Fix unsafe URL schemes in ExternalLink

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -32,3 +32,8 @@
 **Vulnerability:** The Android configuration allowed automatic OS backups (`android:allowBackup="true"`), enabling extraction of unencrypted sensitive health data from `AsyncStorage` via ADB or cloud backups.
 **Learning:** Default framework configurations (like React Native/Expo defaults) often prioritize convenience over security. For health/finance apps, sticking to defaults for data backup is a privacy risk.
 **Prevention:** Explicitly disable backup (`android:allowBackup="false"`) or use `android:fullBackupContent` to exclude sensitive databases if `SecureStore` is not used.
+
+## 2026-02-28 - Unrestricted URL Schemes in ExternalLink
+**Vulnerability:** The `ExternalLink` component blindly passed the `href` prop to `openBrowserAsync` (Native) or `Link` (Web), allowing potential execution of dangerous schemes like `javascript:` (XSS on Web) or `file:` (local file access on Native) if the URL was attacker-controlled.
+**Learning:** Helper components in Expo templates often default to convenience over security. Even if currently unused, they present a risk if later used with dynamic input.
+**Prevention:** Implement strict protocol validation (`http`/`https` only) in all link handling components. Use a centralized validator (`isValidExternalUrl`) to enforce this policy consistently.

--- a/components/ExternalLink.tsx
+++ b/components/ExternalLink.tsx
@@ -1,17 +1,30 @@
 import { Link } from 'expo-router';
 import { openBrowserAsync } from 'expo-web-browser';
 import { type ComponentProps } from 'react';
-import { Platform } from 'react-native';
+import { Platform, Alert } from 'react-native';
+import { isValidExternalUrl } from '@/utils/validation';
 
 type Props = Omit<ComponentProps<typeof Link>, 'href'> & { href: string };
 
 export function ExternalLink({ href, ...rest }: Props) {
+  const isSafe = isValidExternalUrl(href);
+
   return (
     <Link
-      target="_blank"
+      target={isSafe ? "_blank" : undefined}
       {...rest}
-      href={href}
+      href={isSafe ? href : '#'}
       onPress={async (event) => {
+        if (!isSafe) {
+          event.preventDefault();
+          if (Platform.OS !== 'web') {
+            Alert.alert('Security Warning', 'This link was blocked because it uses an unsafe protocol.');
+          } else {
+            console.error(`Blocked insecure link: ${href}`);
+          }
+          return;
+        }
+
         if (Platform.OS !== 'web') {
           // Prevent the default behavior of linking to the default browser on native.
           event.preventDefault();

--- a/components/__tests__/ExternalLink-test.tsx
+++ b/components/__tests__/ExternalLink-test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { ExternalLink } from '../ExternalLink';
+import { openBrowserAsync } from 'expo-web-browser';
+import { Platform, Alert } from 'react-native';
+
+// Mock dependencies
+jest.mock('expo-web-browser', () => ({
+  openBrowserAsync: jest.fn(),
+}));
+
+jest.spyOn(Alert, 'alert');
+
+// Mock Link from expo-router
+jest.mock('expo-router', () => ({
+  Link: jest.fn(({ children, onPress, href }) => {
+    // We render a View with testID to simulate the Link component
+    // We attach the onPress handler passed from ExternalLink to this View
+    const React = require('react');
+    const { View } = require('react-native');
+    return (
+      <View
+        testID="link-wrapper"
+        onTouchEnd={onPress} // For some RN setups, or we can use fireEvent.press if it's Touchable
+        // But Link usually wraps a Touchable. ExternalLink passes onPress to Link.
+        // Let's assume fireEvent.press works if we pass the prop.
+        // Actually, fireEvent.press calls the 'onPress' prop directly if it exists on the element.
+        onPress={onPress}
+      >
+        {children}
+      </View>
+    );
+  }),
+}));
+
+describe('ExternalLink Security', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('blocks dangerous schemes and shows alert on native', async () => {
+    // Ensure we are simulating native
+    Platform.OS = 'ios';
+
+    const dangerousHref = 'javascript:alert(1)';
+
+    const { getByTestId } = render(
+      <ExternalLink href={dangerousHref}>
+        Click me
+      </ExternalLink>
+    );
+
+    const link = getByTestId('link-wrapper');
+
+    // Simulate the press event
+    const mockEvent = { preventDefault: jest.fn() };
+    fireEvent.press(link, mockEvent);
+
+    // Assert that openBrowserAsync was NOT called
+    expect(openBrowserAsync).not.toHaveBeenCalled();
+
+    // Assert that the event was prevented
+    expect(mockEvent.preventDefault).toHaveBeenCalled();
+
+    // Assert that Alert was shown
+    expect(Alert.alert).toHaveBeenCalledWith(
+        'Security Warning',
+        expect.stringContaining('blocked')
+    );
+  });
+});

--- a/utils/__tests__/validation.test.ts
+++ b/utils/__tests__/validation.test.ts
@@ -1,4 +1,4 @@
-import { sanitizeInput, sanitizePromptInput, containsSuspiciousPatterns, validateInputLength, isValidBackupEntry, parseSafePeriodEntries } from '../validation';
+import { sanitizeInput, sanitizePromptInput, containsSuspiciousPatterns, validateInputLength, isValidBackupEntry, parseSafePeriodEntries, isValidExternalUrl } from '../validation';
 
 describe('Validation Utils', () => {
   describe('sanitizeInput', () => {
@@ -182,6 +182,36 @@ describe('Validation Utils', () => {
       expect(parseSafePeriodEntries('{}')).toEqual([]);
       expect(parseSafePeriodEntries('123')).toEqual([]);
       expect(parseSafePeriodEntries('true')).toEqual([]);
+    });
+  });
+
+  describe('isValidExternalUrl', () => {
+    it('allows http links', () => {
+      expect(isValidExternalUrl('http://example.com')).toBe(true);
+    });
+
+    it('allows https links', () => {
+      expect(isValidExternalUrl('https://example.com')).toBe(true);
+    });
+
+    it('rejects javascript:', () => {
+      expect(isValidExternalUrl('javascript:alert(1)')).toBe(false);
+    });
+
+    it('rejects file:', () => {
+      expect(isValidExternalUrl('file:///etc/passwd')).toBe(false);
+    });
+
+    it('rejects invalid schemes', () => {
+      expect(isValidExternalUrl('ftp://example.com')).toBe(false);
+    });
+
+    it('rejects relative urls', () => {
+      expect(isValidExternalUrl('/home')).toBe(false);
+    });
+
+    it('rejects empty', () => {
+      expect(isValidExternalUrl('')).toBe(false);
     });
   });
 });

--- a/utils/validation.ts
+++ b/utils/validation.ts
@@ -186,3 +186,15 @@ export const parseSafePeriodEntries = (json: string | null): any[] => {
     return [];
   }
 };
+
+/**
+ * Validates if the given URL uses a safe protocol (http or https).
+ * This prevents Open Redirects and malicious deep links (e.g. javascript:, file:).
+ * @param url The URL to validate.
+ * @returns True if the URL is safe to open.
+ */
+export const isValidExternalUrl = (url: string): boolean => {
+  if (!url) return false;
+  // Use a regex to check the scheme at the beginning of the string
+  return /^(http|https):\/\//i.test(url);
+};


### PR DESCRIPTION
Secured the `ExternalLink` component by validating the `href` protocol. This prevents execution of dangerous schemes like `javascript:` (XSS on Web) or `file:` (Native) if the URL is dynamic/user-controlled. Added unit tests for validation logic and component behavior. Also updated a snapshot in `PredictionSummary` that had benign formatting differences.

---
*PR created automatically by Jules for task [16858859522350511197](https://jules.google.com/task/16858859522350511197) started by @dhruvhaldar*