### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Unvalidated External Link Vulnerability

### DIFF
--- a/components/ExternalLink.tsx
+++ b/components/ExternalLink.tsx
@@ -1,24 +1,42 @@
 import { Link } from 'expo-router';
 import { openBrowserAsync } from 'expo-web-browser';
 import { type ComponentProps } from 'react';
-import { Platform } from 'react-native';
+import { Platform, Alert } from 'react-native';
+import { isValidExternalUrl } from '@/utils/validation';
 
 type Props = Omit<ComponentProps<typeof Link>, 'href'> & { href: string };
 
 export function ExternalLink({ href, ...rest }: Props) {
+  const isSafe = isValidExternalUrl(href);
+
+  // Security: Prevent rendering unsafe hrefs (like javascript:) on Web
+  const safeHref = isSafe ? href : '#';
+
+  const handlePress = async (event: any) => {
+    if (!isSafe) {
+      event.preventDefault();
+      if (Platform.OS === 'web') {
+        window.alert('Security Warning: Link blocked due to unsafe protocol.');
+      } else {
+        Alert.alert('Security Warning', 'Link blocked due to unsafe protocol.');
+      }
+      return;
+    }
+
+    if (Platform.OS !== 'web') {
+      // Prevent the default behavior of linking to the default browser on native.
+      event.preventDefault();
+      // Open the link in an in-app browser.
+      await openBrowserAsync(href);
+    }
+  };
+
   return (
     <Link
       target="_blank"
       {...rest}
-      href={href}
-      onPress={async (event) => {
-        if (Platform.OS !== 'web') {
-          // Prevent the default behavior of linking to the default browser on native.
-          event.preventDefault();
-          // Open the link in an in-app browser.
-          await openBrowserAsync(href);
-        }
-      }}
+      href={safeHref}
+      onPress={handlePress}
     />
   );
 }

--- a/utils/__tests__/validation.test.ts
+++ b/utils/__tests__/validation.test.ts
@@ -1,4 +1,4 @@
-import { sanitizeInput, sanitizePromptInput, containsSuspiciousPatterns, validateInputLength, isValidBackupEntry, parseSafePeriodEntries } from '../validation';
+import { sanitizeInput, sanitizePromptInput, containsSuspiciousPatterns, validateInputLength, isValidBackupEntry, parseSafePeriodEntries, isValidExternalUrl } from '../validation';
 
 describe('Validation Utils', () => {
   describe('sanitizeInput', () => {
@@ -182,6 +182,38 @@ describe('Validation Utils', () => {
       expect(parseSafePeriodEntries('{}')).toEqual([]);
       expect(parseSafePeriodEntries('123')).toEqual([]);
       expect(parseSafePeriodEntries('true')).toEqual([]);
+    });
+  });
+
+  describe('isValidExternalUrl', () => {
+    it('accepts valid https urls', () => {
+      expect(isValidExternalUrl('https://google.com')).toBe(true);
+      expect(isValidExternalUrl('https://example.com/path?query=1')).toBe(true);
+    });
+
+    it('accepts valid http urls', () => {
+      expect(isValidExternalUrl('http://insecure.com')).toBe(true);
+    });
+
+    it('rejects javascript uri', () => {
+      expect(isValidExternalUrl('javascript:alert(1)')).toBe(false);
+    });
+
+    it('rejects file uri', () => {
+      expect(isValidExternalUrl('file:///etc/passwd')).toBe(false);
+    });
+
+    it('rejects empty string', () => {
+      expect(isValidExternalUrl('')).toBe(false);
+    });
+
+    it('rejects relative paths', () => {
+      expect(isValidExternalUrl('/home')).toBe(false);
+      expect(isValidExternalUrl('home')).toBe(false);
+    });
+
+    it('rejects data uri', () => {
+      expect(isValidExternalUrl('data:text/html,<script>alert(1)</script>')).toBe(false);
     });
   });
 });

--- a/utils/validation.ts
+++ b/utils/validation.ts
@@ -186,3 +186,13 @@ export const parseSafePeriodEntries = (json: string | null): any[] => {
     return [];
   }
 };
+
+/**
+ * Checks if a URL is a valid external URL (http/https).
+ * @param url The URL to check.
+ * @returns True if valid.
+ */
+export const isValidExternalUrl = (url: string): boolean => {
+  if (!url) return false;
+  return /^(https?:\/\/)/i.test(url);
+};


### PR DESCRIPTION
This PR addresses a security enhancement by validating URLs in the `ExternalLink` component. 

Changes:
1.  **Validation Utility**: Added `isValidExternalUrl` to `utils/validation.ts` which strictly allows only `http://` and `https://` protocols.
2.  **Component Security**: Updated `components/ExternalLink.tsx` to use this validation. If an unsafe URL is provided:
    *   On Web: The `href` attribute is replaced with `#` to prevent the link from executing unsafe schemes (like `javascript:`) if clicked. `window.alert` is shown.
    *   On Native: `openBrowserAsync` is blocked, and `Alert.alert` is shown.
3.  **Tests**: Added unit tests for `isValidExternalUrl` covering various valid and invalid cases.
4.  **Snapshots**: Updated `PredictionSummary` snapshots to reflect current state (minor whitespace diff).

This fixes a potential vulnerability where `ExternalLink` could be used to execute XSS or open local files if user input were passed to it. Although the component is currently unused, this follows Defense in Depth principles.


---
*PR created automatically by Jules for task [10891230072618321787](https://jules.google.com/task/10891230072618321787) started by @dhruvhaldar*