### PR TITLE
🎨 Palette: Disable Chat Input Submit When Empty

### DIFF
--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -24,10 +24,12 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(({ onSubmit
     clear: () => setText(''),
   }));
 
+  const isInputEmpty = text.trim().length === 0;
+  const isButtonDisabled = isLoading || isInputEmpty;
+
   const handleSubmit = () => {
-    const trimmedText = text.trim();
-    if (trimmedText) {
-      onSubmit(trimmedText);
+    if (!isButtonDisabled) {
+      onSubmit(text.trim());
       setText(''); // Auto-clear on submit
     }
   };
@@ -46,12 +48,12 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(({ onSubmit
             onSubmitEditing={handleSubmit}
         />
         <TouchableOpacity
-            style={styles.button}
+            style={[styles.button, isButtonDisabled && styles.buttonDisabled]}
             onPress={handleSubmit}
-            disabled={isLoading}
+            disabled={isButtonDisabled}
             accessibilityLabel="Send question to AI assistant"
             accessibilityRole="button"
-            accessibilityState={{ disabled: isLoading, busy: isLoading }}
+            accessibilityState={{ disabled: isButtonDisabled, busy: isLoading }}
         >
             {isLoading ? <ActivityIndicator color="#F1FAEE" /> : <ThemedText style={styles.buttonText}>Ask 🔍</ThemedText>}
         </TouchableOpacity>
@@ -77,6 +79,9 @@ const styles = StyleSheet.create({
     padding: 12,
     borderRadius: 25,
     alignItems: 'center',
+  },
+  buttonDisabled: {
+    opacity: 0.5,
   },
   buttonText: {
     color: 'white',

--- a/components/__tests__/ChatInput-test.tsx
+++ b/components/__tests__/ChatInput-test.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { ChatInput } from '../ChatInput';
+
+describe('ChatInput', () => {
+  const mockOnSubmit = jest.fn();
+
+  beforeEach(() => {
+    mockOnSubmit.mockClear();
+  });
+
+  it('renders correctly', () => {
+    const { getByPlaceholderText } = render(
+      <ChatInput
+        onSubmit={mockOnSubmit}
+        isLoading={false}
+        textColor="#000"
+        placeholderTextColor="#666"
+      />
+    );
+    expect(getByPlaceholderText('Ask a menstrual health question...')).toBeTruthy();
+  });
+
+  it('is disabled when input is empty', () => {
+    const { getByRole } = render(
+      <ChatInput
+        onSubmit={mockOnSubmit}
+        isLoading={false}
+        textColor="#000"
+        placeholderTextColor="#666"
+      />
+    );
+    const button = getByRole('button', { name: 'Send question to AI assistant' });
+    expect(button.props.accessibilityState.disabled).toBe(true);
+  });
+
+  it('is disabled when input is whitespace', () => {
+    const { getByRole, getByPlaceholderText } = render(
+      <ChatInput
+        onSubmit={mockOnSubmit}
+        isLoading={false}
+        textColor="#000"
+        placeholderTextColor="#666"
+      />
+    );
+    const input = getByPlaceholderText('Ask a menstrual health question...');
+    fireEvent.changeText(input, '   ');
+
+    const button = getByRole('button', { name: 'Send question to AI assistant' });
+    expect(button.props.accessibilityState.disabled).toBe(true);
+  });
+
+  it('is enabled when input has text', () => {
+    const { getByRole, getByPlaceholderText } = render(
+      <ChatInput
+        onSubmit={mockOnSubmit}
+        isLoading={false}
+        textColor="#000"
+        placeholderTextColor="#666"
+      />
+    );
+    const input = getByPlaceholderText('Ask a menstrual health question...');
+    fireEvent.changeText(input, 'Hello');
+
+    const button = getByRole('button', { name: 'Send question to AI assistant' });
+    expect(button.props.accessibilityState.disabled).toBeFalsy();
+  });
+
+  it('is disabled when isLoading is true, even with text', () => {
+    const { getByRole, getByPlaceholderText } = render(
+        <ChatInput
+          onSubmit={mockOnSubmit}
+          isLoading={true}
+          textColor="#000"
+          placeholderTextColor="#666"
+        />
+      );
+      const input = getByPlaceholderText('Ask a menstrual health question...');
+      fireEvent.changeText(input, 'Hello');
+
+      const button = getByRole('button', { name: 'Send question to AI assistant' });
+      expect(button.props.accessibilityState.disabled).toBe(true);
+  });
+});


### PR DESCRIPTION
This change improves the UX of the ChatInput component by preventing users from submitting empty or whitespace-only queries. It provides visual feedback by dimming the submit button and ensures accessibility tools correctly report the button as disabled. A new test suite was added to verify these behaviors.

---
*PR created automatically by Jules for task [1381907544315016046](https://jules.google.com/task/1381907544315016046) started by @dhruvhaldar*