### PR TITLE
🎨 Palette: Improve keyboard interaction in scroll views

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-23 - Encapsulating Haptics in UI Components
 **Learning:** Platform-specific logic (like `Haptics` checks for Web vs Native) clutters screen components and leads to inconsistency.
 **Action:** Encapsulate this logic within reusable UI components (like `Switch`, `SelectionButton`). This ensures every interaction feels premium and consistent across platforms without repetitive code in screens.
+
+## 2025-05-24 - Enhancing ScrollView Interactions
+**Learning:** Default ScrollView behavior (locking taps when keyboard is up, not dismissing keyboard on drag) frustrates users during form entry.
+**Action:** Always configure `keyboardDismissMode="on-drag"` and `keyboardShouldPersistTaps="handled"` in scrollable containers wrapping forms to create a fluid, native-feeling experience.

--- a/components/ParallaxScrollView.tsx
+++ b/components/ParallaxScrollView.tsx
@@ -16,12 +16,16 @@ const HEADER_HEIGHT = 150;
 type Props = PropsWithChildren<{
   headerImage: ReactElement;
   headerBackgroundColor: { dark: string; light: string };
+  keyboardDismissMode?: 'none' | 'on-drag' | 'interactive';
+  keyboardShouldPersistTaps?: 'always' | 'never' | 'handled';
 }>;
 
 export default function ParallaxScrollView({
   children,
   headerImage,
   headerBackgroundColor,
+  keyboardDismissMode = 'on-drag',
+  keyboardShouldPersistTaps = 'handled',
 }: Props) {
   const colorScheme = useColorScheme() ?? 'light';
   const scrollRef = useAnimatedRef<Animated.ScrollView>();
@@ -61,7 +65,9 @@ export default function ParallaxScrollView({
         ref={scrollRef}
         scrollEventThrottle={16}
         scrollIndicatorInsets={{ bottom }}
-        contentContainerStyle={{ paddingBottom: bottom }}>
+        contentContainerStyle={{ paddingBottom: bottom }}
+        keyboardDismissMode={keyboardDismissMode}
+        keyboardShouldPersistTaps={keyboardShouldPersistTaps}>
         {header}
         <ThemedView style={styles.content}>{children}</ThemedView>
       </Animated.ScrollView>


### PR DESCRIPTION
This PR improves the user experience when interacting with forms in scroll views.
- **Problem:** Previously, the keyboard would not dismiss when scrolling, and tapping buttons (like "Log Period") required two taps (one to dismiss keyboard, one to activate).
- **Solution:** Added `keyboardDismissMode="on-drag"` and `keyboardShouldPersistTaps="handled"` to `ParallaxScrollView`. This makes the keyboard dismiss naturally when scrolling and allows buttons to be tapped immediately.
- **Maintenance:** Updated a stale snapshot for `PredictionSummary`.

---
*PR created automatically by Jules for task [16780951356108524373](https://jules.google.com/task/16780951356108524373) started by @dhruvhaldar*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard behavior configuration options to the scrollable container component with improved defaults for better form interactions.

* **Documentation**
  * Added guidance for optimizing keyboard behavior in scrollable containers with forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->