### PR TITLE
⚡ Bolt: Deduplicate concurrent PeriodStorage reads

### DIFF
--- a/utils/__tests__/storage.test.ts
+++ b/utils/__tests__/storage.test.ts
@@ -44,6 +44,26 @@ describe('PeriodStorage', () => {
     expect(AsyncStorage.getItem).toHaveBeenCalledTimes(1); // Call count remains 1
   });
 
+  it('deduplicates concurrent getEntries calls', async () => {
+    // Bolt Optimization Test: Verify deduplication
+    // Simulate a slow async operation
+    (AsyncStorage.getItem as jest.Mock).mockImplementation(() =>
+      new Promise(resolve => setTimeout(() => resolve('concurrent-data'), 10))
+    );
+
+    // Call getEntries twice concurrently
+    const promise1 = PeriodStorage.getEntries();
+    const promise2 = PeriodStorage.getEntries();
+
+    const [result1, result2] = await Promise.all([promise1, promise2]);
+
+    expect(result1).toBe('concurrent-data');
+    expect(result2).toBe('concurrent-data');
+
+    // Should only hit AsyncStorage once
+    expect(AsyncStorage.getItem).toHaveBeenCalledTimes(1);
+  });
+
   it('saveEntries updates cache and calls AsyncStorage', async () => {
     const newData = 'new-data';
     await PeriodStorage.saveEntries(newData);

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -8,19 +8,38 @@ import { AppState, AppStateStatus } from 'react-native';
  */
 
 let cachedEntries: string | null = null;
+// Bolt Optimization: Track pending promise to deduplicate concurrent requests
+let pendingGetEntriesPromise: Promise<string | null> | null = null;
 
 export const PeriodStorage = {
   /**
    * Retrieves period entries from cache or AsyncStorage.
    * If available in cache, returns immediately without async bridge call.
+   * If a fetch is already in progress, returns the existing promise (deduplication).
    */
   async getEntries(): Promise<string | null> {
     if (cachedEntries !== null) {
       return cachedEntries;
     }
-    const entries = await AsyncStorage.getItem('periodEntries');
-    cachedEntries = entries;
-    return entries;
+
+    // Bolt Optimization: If a request is already in flight, reuse it.
+    // This prevents multiple AsyncStorage calls when multiple components load simultaneously.
+    if (pendingGetEntriesPromise) {
+      return pendingGetEntriesPromise;
+    }
+
+    pendingGetEntriesPromise = (async () => {
+      try {
+        const entries = await AsyncStorage.getItem('periodEntries');
+        cachedEntries = entries;
+        return entries;
+      } finally {
+        // Clear the pending promise so future calls can retry if needed (though cache should handle it)
+        pendingGetEntriesPromise = null;
+      }
+    })();
+
+    return pendingGetEntriesPromise;
   },
 
   /**
@@ -37,6 +56,7 @@ export const PeriodStorage = {
    */
   clearCache() {
     cachedEntries = null;
+    pendingGetEntriesPromise = null;
   }
 };
 


### PR DESCRIPTION
💡 What: Implemented promise deduplication in `PeriodStorage.getEntries()` to prevent concurrent `AsyncStorage` calls.
🎯 Why: Multiple components (like Home, History, Insights) might request data simultaneously on app startup, triggering redundant bridge crossings and disk reads.
📊 Impact: Ensures only one `AsyncStorage.getItem` call is made during concurrent fetch requests, reducing startup overhead and potential race conditions.
🔬 Measurement: Added a unit test in `utils/__tests__/storage.test.ts` to verify that concurrent calls result in a single underlying storage request.

---
*PR created automatically by Jules for task [11928699456872779520](https://jules.google.com/task/11928699456872779520) started by @dhruvhaldar*