### PR TITLE
🎨 Palette: Eliminate Flash of Empty State

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2025-10-29 - Tappable Settings Rows
 **Learning:** Small toggle switches have poor touch targets, frustrating users and failing accessibility guidelines for motor impairments.
 **Action:** Wrap the entire settings row (label + switch) in a `TouchableOpacity`. Apply `accessibilityRole="switch"` to the wrapper and hide the internal switch from accessibility (`accessible={false}`, `pointerEvents="none"`), creating a large, single touch target that behaves natively.
+
+## 2025-10-30 - Flash of Empty State
+**Learning:** When fetching data asynchronously, initializing with an empty array causes the "Empty State" component to render briefly before data arrives, creating a jarring experience.
+**Action:** Initialize with an `isLoading` state (true) and only render the "Empty State" component when `!isLoading && data.length === 0`.

--- a/app/(tabs)/history.tsx
+++ b/app/(tabs)/history.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useRef, useMemo } from 'react';
-import { StyleSheet, View, Alert, useColorScheme, Platform, UIManager, Vibration, LayoutAnimation } from 'react-native';
+import { StyleSheet, View, Alert, useColorScheme, Platform, UIManager, Vibration, LayoutAnimation, ActivityIndicator } from 'react-native';
 // Remove direct AsyncStorage import
 // import AsyncStorage from '@react-native-async-storage/async-storage';
 import { PeriodStorage } from '@/utils/storage';
@@ -14,6 +14,7 @@ import { parseSafePeriodEntries } from '@/utils/validation';
 export default function TabTwoScreen() {
   const router = useRouter();
   const [entries, setEntries] = useState<HistoryEntry[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
   // Ref to store the raw string of the last fetched entries to avoid unnecessary re-parsing and re-renders
   const lastFetchedEntriesRef = useRef<string | null>(null);
   
@@ -51,6 +52,8 @@ export default function TabTwoScreen() {
       setEntries(parsedEntries);
     } catch (error: any) {
       console.error('Error fetching period entries:', error instanceof Error ? error.message : String(error));
+    } finally {
+      setIsLoading(false);
     }
   };
   
@@ -118,15 +121,24 @@ export default function TabTwoScreen() {
   }, [router]);
 
   // Optimization: Memoize empty state component to prevent re-mounting/re-rendering
-  const emptyState = useMemo(() => (
-    <EmptyState
-      title="No Entries Yet"
-      message="Track your first period to start seeing your history here."
-      icon="clock.fill"
-      actionLabel="Log Period"
-      onAction={handleEmptyAction}
-    />
-  ), [handleEmptyAction]);
+  const emptyState = useMemo(() => {
+    if (isLoading) {
+      return (
+        <View style={{ padding: 20, alignItems: 'center' }}>
+          <ActivityIndicator size="large" color="#E63946" />
+        </View>
+      );
+    }
+    return (
+      <EmptyState
+        title="No Entries Yet"
+        message="Track your first period to start seeing your history here."
+        icon="clock.fill"
+        actionLabel="Log Period"
+        onAction={handleEmptyAction}
+      />
+    );
+  }, [handleEmptyAction, isLoading]);
  
   // Optimization: Memoize the list header to ensure referential stability.
   // This prevents the ParallaxFlatList (and underlying FlatList) from unmounting/remounting

--- a/app/(tabs)/insights.tsx
+++ b/app/(tabs)/insights.tsx
@@ -4,7 +4,8 @@ import {
   View, 
   Image, 
   useColorScheme, 
-  Dimensions 
+  Dimensions,
+  ActivityIndicator
 } from 'react-native';
 // Remove direct AsyncStorage import
 // import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -24,6 +25,7 @@ const screenWidth = Dimensions.get('window').width;
 export default function InsightsScreen() {
   const router = useRouter();
   const [entries, setEntries] = useState<HistoryEntry[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
   const lastFetchedEntriesRef = useRef<string | null>(null);
 
   // Color Scheme
@@ -69,6 +71,8 @@ export default function InsightsScreen() {
       setEntries(parsedEntries);
     } catch (error: any) {
       console.error('Error fetching entries:', error instanceof Error ? error.message : String(error));
+    } finally {
+      setIsLoading(false);
     }
   };
 
@@ -225,7 +229,11 @@ export default function InsightsScreen() {
         <ThemedView style={styles.sectionContainer}>
           <ThemedText type="subtitle" style={{ color: sectionHeadingtextColor, marginBottom: 10 }}> Previous Cycles </ThemedText>
           
-          {cycleData.length > 0 ? (  
+          {isLoading ? (
+            <View style={{ padding: 20, alignItems: 'center' }}>
+              <ActivityIndicator size="large" color="#E63946" />
+            </View>
+          ) : cycleData.length > 0 ? (
             <VictoryBar 
             data={cycleData} horizontal 
             barRatio={0.2} // Adjusted to make bars shorter


### PR DESCRIPTION
💡 What: Added `isLoading` state to History and Insights screens to show a spinner during initial data fetch.
🎯 Why: Users were seeing "No Entries Yet" briefly before data loaded, which is jarring and confusing.
♿ Accessibility: Improves perceived performance and reduces cognitive load by not showing misleading empty states.

---
*PR created automatically by Jules for task [7708633280986857374](https://jules.google.com/task/7708633280986857374) started by @dhruvhaldar*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Loading indicators now display in History and Insights tabs while data loads, eliminating the empty state flash.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->