### PR TITLE
🛡️ Sentinel: Fix PHI Remanence in UI State

### DIFF
--- a/app/(tabs)/history.tsx
+++ b/app/(tabs)/history.tsx
@@ -1,22 +1,28 @@
-import React, { useState, useCallback, useRef, useMemo } from 'react';
-import { StyleSheet, View, Alert, useColorScheme, Platform, UIManager, Vibration, LayoutAnimation } from 'react-native';
+import React, { useCallback, useMemo } from 'react';
+import { StyleSheet, View, Alert, useColorScheme, Platform, UIManager, Vibration, LayoutAnimation, ActivityIndicator } from 'react-native';
 // Remove direct AsyncStorage import
 // import AsyncStorage from '@react-native-async-storage/async-storage';
 import { PeriodStorage } from '@/utils/storage';
 import { ThemedText } from '@/components/ThemedText';
 import ParallaxFlatList from '@/components/ParallaxFlatList';
-import { useFocusEffect, useRouter } from 'expo-router';
+import { useRouter } from 'expo-router';
 import { Image } from 'react-native';
 import HistoryItem, { HistoryEntry } from '@/components/HistoryItem';
 import { EmptyState } from '@/components/ui/EmptyState';
-import { parseSafePeriodEntries } from '@/utils/validation';
+import { usePeriodEntries } from '@/hooks/usePeriodEntries';
 
 export default function TabTwoScreen() {
   const router = useRouter();
-  const [entries, setEntries] = useState<HistoryEntry[]>([]);
-  // Ref to store the raw string of the last fetched entries to avoid unnecessary re-parsing and re-renders
-  const lastFetchedEntriesRef = useRef<string | null>(null);
+  // Security: usePeriodEntries hook ensures PHI is cleared from memory when backgrounded
+  const { entries: rawEntries, isLoading, setEntries } = usePeriodEntries();
   
+  // Sort entries for display
+  const entries = useMemo(() => {
+    const sorted = [...rawEntries];
+    sorted.sort((a, b) => b.lastPeriod.localeCompare(a.lastPeriod));
+    return sorted;
+  }, [rawEntries]);
+
   // Color Scheme
   const colorScheme = useColorScheme();
   const Parallaxheaderlightcolor = '#A8DADC';
@@ -24,35 +30,6 @@ export default function TabTwoScreen() {
   const sectionHeadingtextColor = colorScheme === 'dark' ? '#E63946' : '#1D3557';
   const textColor = colorScheme === 'dark' ? '#F1FAEE' : '#1D3557';
   const deleteIconColor = colorScheme === 'dark' ? '#F1FAEE' : '#E63946';
-
-
-  useFocusEffect(
-    useCallback(() => {
-      fetchEntries();
-    }, [])
-  );
-
-  const fetchEntries = async () => {
-    try {
-      // Bolt Optimization: Use cached PeriodStorage to avoid disk reads on tab switch
-      const storedEntries = await PeriodStorage.getEntries();
-      
-      // Optimization: Only parse and update state if the data has actually changed
-      if (storedEntries === lastFetchedEntriesRef.current) {
-        return;
-      }
-      lastFetchedEntriesRef.current = storedEntries;
-
-      // Security: Safely parse entries to prevent DoS/Crashes if storage is corrupted
-      const parsedEntries = parseSafePeriodEntries(storedEntries);
-      // Sort by lastPeriod in descending order (most recent first)
-      // Optimization: Use string comparison for ISO dates to avoid expensive Date object creation
-      parsedEntries.sort((a, b) => b.lastPeriod.localeCompare(a.lastPeriod));
-      setEntries(parsedEntries);
-    } catch (error: any) {
-      console.error('Error fetching period entries:', error instanceof Error ? error.message : String(error));
-    }
-  };
   
   if (Platform.OS === 'android' && UIManager.setLayoutAnimationEnabledExperimental) {
     UIManager.setLayoutAnimationEnabledExperimental(true);
@@ -80,10 +57,7 @@ export default function TabTwoScreen() {
                 const newEntriesString = JSON.stringify(updatedEntries);
 
                 // Bolt Optimization: Use PeriodStorage to save and update cache
-                PeriodStorage.saveEntries(newEntriesString).then(() => {
-                  // Update the ref to prevent the next fetch (e.g. on focus) from re-rendering if it matches
-                  lastFetchedEntriesRef.current = newEntriesString;
-                }).catch(err =>
+                PeriodStorage.saveEntries(newEntriesString).catch(err =>
                   console.error('Failed to persist deletion', err instanceof Error ? err.message : String(err))
                 );
                 return updatedEntries;
@@ -98,7 +72,7 @@ export default function TabTwoScreen() {
         },
       ]
     );
-  }, []); // useCallback dependency array is empty because we use functional state update
+  }, [setEntries]);
 
   const renderItem = useCallback(({ item }: { item: HistoryEntry }) => (
     <HistoryItem
@@ -119,14 +93,18 @@ export default function TabTwoScreen() {
 
   // Optimization: Memoize empty state component to prevent re-mounting/re-rendering
   const emptyState = useMemo(() => (
-    <EmptyState
-      title="No Entries Yet"
-      message="Track your first period to start seeing your history here."
-      icon="clock.fill"
-      actionLabel="Log Period"
-      onAction={handleEmptyAction}
-    />
-  ), [handleEmptyAction]);
+    isLoading ? (
+       <ActivityIndicator size="large" color={textColor} style={{ marginTop: 20 }} />
+    ) : (
+      <EmptyState
+        title="No Entries Yet"
+        message="Track your first period to start seeing your history here."
+        icon="clock.fill"
+        actionLabel="Log Period"
+        onAction={handleEmptyAction}
+      />
+    )
+  ), [isLoading, textColor, handleEmptyAction]);
  
   // Optimization: Memoize the list header to ensure referential stability.
   // This prevents the ParallaxFlatList (and underlying FlatList) from unmounting/remounting

--- a/app/(tabs)/insights.tsx
+++ b/app/(tabs)/insights.tsx
@@ -1,30 +1,29 @@
-import React, { useState, useCallback, useMemo, useRef } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { 
   StyleSheet, 
   View, 
   Image, 
   useColorScheme, 
-  Dimensions 
+  Dimensions,
+  ActivityIndicator
 } from 'react-native';
 // Remove direct AsyncStorage import
 // import AsyncStorage from '@react-native-async-storage/async-storage';
-import { PeriodStorage } from '@/utils/storage';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
 import ParallaxScrollView from '@/components/ParallaxScrollView';
 import { VictoryBar, VictoryLabel } from 'victory-native';
-import { useFocusEffect, useRouter } from 'expo-router';
+import { useRouter } from 'expo-router';
 import { EmptyState } from '@/components/ui/EmptyState';
 import { formatDate, DateFormats } from '@/utils/dateFormatter';
-import { HistoryEntry } from '@/components/HistoryItem';
-import { parseSafePeriodEntries } from '@/utils/validation';
+import { usePeriodEntries } from '@/hooks/usePeriodEntries';
 
 const screenWidth = Dimensions.get('window').width;
 
 export default function InsightsScreen() {
   const router = useRouter();
-  const [entries, setEntries] = useState<HistoryEntry[]>([]);
-  const lastFetchedEntriesRef = useRef<string | null>(null);
+  // Security: usePeriodEntries hook ensures PHI is cleared from memory when backgrounded
+  const { entries, isLoading } = usePeriodEntries();
 
   // Color Scheme
   const colorScheme = useColorScheme();
@@ -45,32 +44,6 @@ export default function InsightsScreen() {
 
   const sectionHeadingtextColor = colorScheme === 'dark' ? '#E63946' : '#1D3557';
   const barColor = colorScheme === 'dark' ? '#F1FAEE' : '#457B9D';
-
-  useFocusEffect(
-    useCallback(() => {
-      fetchEntries();
-    }, [])
-  );
-
-  const fetchEntries = async () => {
-    try {
-      // Bolt Optimization: Use cached PeriodStorage to avoid disk reads on tab switch
-      const storedEntries = await PeriodStorage.getEntries();
-
-      // Optimization: Only parse and update state if the data has actually changed
-      if (storedEntries === lastFetchedEntriesRef.current) {
-        return;
-      }
-      lastFetchedEntriesRef.current = storedEntries;
-
-      // Security: Safely parse entries to prevent DoS/Crashes if storage is corrupted
-      const parsedEntries = parseSafePeriodEntries(storedEntries);
-      // Note: We're just setting entries here. Sorting and derivation happen in useMemo.
-      setEntries(parsedEntries);
-    } catch (error: any) {
-      console.error('Error fetching entries:', error instanceof Error ? error.message : String(error));
-    }
-  };
 
   // ⚡ Bolt: Derived State Optimization
   // Instead of syncing state with useEffect/functions, we derive expensive data during render.
@@ -221,103 +194,107 @@ export default function InsightsScreen() {
       <ThemedView style={styles.container}>
         <ThemedText type="title" style={[styles.title, { color: sectionHeadingtextColor }]}>Cycle Insights</ThemedText>
 
-        {/* Previous Cycles Section */}
-        <ThemedView style={styles.sectionContainer}>
-          <ThemedText type="subtitle" style={{ color: sectionHeadingtextColor, marginBottom: 10 }}> Previous Cycles </ThemedText>
-          
-          {cycleData.length > 0 ? (  
-            <VictoryBar 
-            data={cycleData} horizontal 
-            barRatio={0.2} // Adjusted to make bars shorter
-            labels={getBarLabel}
-            labelComponent={barLabelComponent}
-            style={barStyle}
-            width={screenWidth - 150} // Width of bar - 150 pixels
-            padding={{ top: 20, left: 5, right: 110, bottom: 20 }}
-          />
-          ) : (
-            <EmptyState
-              title="No Insights Yet"
-              message="Log more periods to unlock trends and insights."
-              icon="chart.bar.fill"
-              actionLabel="Log Now"
-              onAction={() => router.push('/')}
-              style={{ marginTop: 10, padding: 20 }}
-            />
-          )}
-        </ThemedView>
+        {isLoading ? (
+          <ActivityIndicator size="large" color={barColor} style={{ marginTop: 50 }} />
+        ) : (
+          <>
+            {/* Previous Cycles Section */}
+            <ThemedView style={styles.sectionContainer}>
+              <ThemedText type="subtitle" style={{ color: sectionHeadingtextColor, marginBottom: 10 }}> Previous Cycles </ThemedText>
 
-        
-        
-        {/* Key Metrics Section */}
-        <ThemedView style={styles.sectionContainer}>
-          <ThemedText type="subtitle" style={{ color: sectionHeadingtextColor, marginBottom: 10 }}>
-            Key Metrics 📊
-          </ThemedText>
-          <View style={styles.metricsContainer}>
-            <View
-              style={styles.metricItem}
-              accessible={true}
-              accessibilityLabel={`Average Cycle Length: ${isNaN(averageCycleLength) ? 'N/A' : `${averageCycleLength} days`}`}
-            >
-              <ThemedText>Avg. Cycle Length</ThemedText>
-              <ThemedText type="subtitle">
-                {isNaN(averageCycleLength) ? 'N/A' : `${averageCycleLength} days`}
+              {cycleData.length > 0 ? (
+                <VictoryBar
+                data={cycleData} horizontal
+                barRatio={0.2} // Adjusted to make bars shorter
+                labels={getBarLabel}
+                labelComponent={barLabelComponent}
+                style={barStyle}
+                width={screenWidth - 150} // Width of bar - 150 pixels
+                padding={{ top: 20, left: 5, right: 110, bottom: 20 }}
+              />
+              ) : (
+                <EmptyState
+                  title="No Insights Yet"
+                  message="Log more periods to unlock trends and insights."
+                  icon="chart.bar.fill"
+                  actionLabel="Log Now"
+                  onAction={() => router.push('/')}
+                  style={{ marginTop: 10, padding: 20 }}
+                />
+              )}
+            </ThemedView>
+
+            {/* Key Metrics Section */}
+            <ThemedView style={styles.sectionContainer}>
+              <ThemedText type="subtitle" style={{ color: sectionHeadingtextColor, marginBottom: 10 }}>
+                Key Metrics 📊
               </ThemedText>
-            </View>
+              <View style={styles.metricsContainer}>
+                <View
+                  style={styles.metricItem}
+                  accessible={true}
+                  accessibilityLabel={`Average Cycle Length: ${isNaN(averageCycleLength) ? 'N/A' : `${averageCycleLength} days`}`}
+                >
+                  <ThemedText>Avg. Cycle Length</ThemedText>
+                  <ThemedText type="subtitle">
+                    {isNaN(averageCycleLength) ? 'N/A' : `${averageCycleLength} days`}
+                  </ThemedText>
+                </View>
 
-            <View
-              style={styles.metricItem}
-              accessible={true}
-              accessibilityLabel={`Average Period Duration: ${isNaN(averagePeriodDuration) ? 'N/A' : `${averagePeriodDuration} days`}`}
-            >
-              <ThemedText>Avg. Period Duration</ThemedText>
-              <ThemedText type="subtitle">
-                {isNaN(averagePeriodDuration) ? 'N/A' : `${averagePeriodDuration} days`}
-              </ThemedText>
-            </View>
+                <View
+                  style={styles.metricItem}
+                  accessible={true}
+                  accessibilityLabel={`Average Period Duration: ${isNaN(averagePeriodDuration) ? 'N/A' : `${averagePeriodDuration} days`}`}
+                >
+                  <ThemedText>Avg. Period Duration</ThemedText>
+                  <ThemedText type="subtitle">
+                    {isNaN(averagePeriodDuration) ? 'N/A' : `${averagePeriodDuration} days`}
+                  </ThemedText>
+                </View>
 
-            <View
-              style={styles.metricItem}
-              accessible={true}
-              accessibilityLabel={`Average Ovulation Day: ${isNaN(averageOvulationDay) ? 'N/A' : `Day ${averageOvulationDay}`}`}
-            >
-              <ThemedText>Avg. Ovulation Day</ThemedText>
-              <ThemedText type="subtitle">
-                {isNaN(averageOvulationDay) ? 'N/A' : `Day ${averageOvulationDay}`}
-              </ThemedText>
-            </View>
+                <View
+                  style={styles.metricItem}
+                  accessible={true}
+                  accessibilityLabel={`Average Ovulation Day: ${isNaN(averageOvulationDay) ? 'N/A' : `Day ${averageOvulationDay}`}`}
+                >
+                  <ThemedText>Avg. Ovulation Day</ThemedText>
+                  <ThemedText type="subtitle">
+                    {isNaN(averageOvulationDay) ? 'N/A' : `Day ${averageOvulationDay}`}
+                  </ThemedText>
+                </View>
 
-            <View
-              style={styles.metricItem}
-              accessible={true}
-              accessibilityLabel={`Next Period Prediction: ${nextPeriodPrediction}`}
-            >
-              <ThemedText>Next Period Prediction</ThemedText>
-              <ThemedText type="subtitle">{nextPeriodPrediction}</ThemedText>
-            </View>
+                <View
+                  style={styles.metricItem}
+                  accessible={true}
+                  accessibilityLabel={`Next Period Prediction: ${nextPeriodPrediction}`}
+                >
+                  <ThemedText>Next Period Prediction</ThemedText>
+                  <ThemedText type="subtitle">{nextPeriodPrediction}</ThemedText>
+                </View>
 
-            <View
-              style={styles.metricItem}
-              accessible={true}
-              accessibilityLabel={`Next Ovulation Prediction: ${nextOvulationPrediction}`}
-            >
-              <ThemedText>Next Ovulation Prediction</ThemedText>
-              <ThemedText type="subtitle">{nextOvulationPrediction}</ThemedText>
-            </View>
+                <View
+                  style={styles.metricItem}
+                  accessible={true}
+                  accessibilityLabel={`Next Ovulation Prediction: ${nextOvulationPrediction}`}
+                >
+                  <ThemedText>Next Ovulation Prediction</ThemedText>
+                  <ThemedText type="subtitle">{nextOvulationPrediction}</ThemedText>
+                </View>
 
-            <View
-              style={styles.metricItem}
-              accessible={true}
-              accessibilityLabel={`Periods Tracked: ${entries.length}`}
-            >
-              <ThemedText>Periods Tracked</ThemedText>
-              <ThemedText type="subtitle">
-                {entries.length}
-              </ThemedText>
-            </View>
-          </View>
-        </ThemedView>
+                <View
+                  style={styles.metricItem}
+                  accessible={true}
+                  accessibilityLabel={`Periods Tracked: ${entries.length}`}
+                >
+                  <ThemedText>Periods Tracked</ThemedText>
+                  <ThemedText type="subtitle">
+                    {entries.length}
+                  </ThemedText>
+                </View>
+              </View>
+            </ThemedView>
+          </>
+        )}
 
       </ThemedView>
     </ParallaxScrollView>

--- a/hooks/usePeriodEntries.ts
+++ b/hooks/usePeriodEntries.ts
@@ -1,0 +1,68 @@
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { AppState, AppStateStatus } from 'react-native';
+import { PeriodStorage } from '@/utils/storage';
+import { parseSafePeriodEntries } from '@/utils/validation';
+import { useFocusEffect } from 'expo-router';
+import { HistoryEntry } from '@/components/HistoryItem';
+
+export function usePeriodEntries() {
+  const [entries, setEntries] = useState<HistoryEntry[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  // Ref to store the raw string of the last fetched entries to avoid unnecessary re-parsing and re-renders
+  const lastFetchedEntriesRef = useRef<string | null>(null);
+
+  const fetchEntries = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      // Bolt Optimization: Use cached PeriodStorage to avoid disk reads on tab switch
+      const storedEntries = await PeriodStorage.getEntries();
+
+      // Optimization: Only parse and update state if the data has actually changed
+      if (storedEntries === lastFetchedEntriesRef.current) {
+        setIsLoading(false);
+        return;
+      }
+      lastFetchedEntriesRef.current = storedEntries;
+
+      // Security: Safely parse entries to prevent DoS/Crashes if storage is corrupted
+      const parsedEntries = parseSafePeriodEntries(storedEntries);
+      setEntries(parsedEntries);
+    } catch (error: any) {
+      console.error('Error fetching period entries:', error instanceof Error ? error.message : String(error));
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  // Fetch on navigation focus
+  useFocusEffect(
+    useCallback(() => {
+      fetchEntries();
+    }, [fetchEntries])
+  );
+
+  // Security: Clear sensitive data on background
+  useEffect(() => {
+    const subscription = AppState.addEventListener('change', (nextAppState: AppStateStatus) => {
+      if (nextAppState === 'background') {
+        // Clear sensitive PHI from memory when app is backgrounded
+        setEntries([]);
+        lastFetchedEntriesRef.current = null; // Reset cache ref to ensure re-fetch on return
+      } else if (nextAppState === 'active') {
+        // Re-fetch data when app comes to foreground
+        fetchEntries();
+      }
+    });
+
+    return () => {
+      subscription.remove();
+    };
+  }, [fetchEntries]);
+
+  return {
+    entries,
+    isLoading,
+    refresh: fetchEntries,
+    setEntries
+  };
+}


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix PHI Remanence in UI State

🚨 Severity: MEDIUM
💡 Vulnerability: Sensitive health data (PHI) stored in component state (HistoryScreen, InsightsScreen) remained in memory when the app was backgrounded, even though the storage cache was cleared. This could lead to data leakage via memory scraping or task snapshots.
🎯 Impact: Attackers with physical access or malware could potentially access sensitive health data from RAM even if the app was locked or backgrounded.
🔧 Fix: Implemented `usePeriodEntries` hook that listens to `AppState` and explicitly clears the `entries` state when the app goes to background. It re-fetches data when the app returns to foreground.
✅ Verification: Verified that `setEntries([])` is called on background transition via code review and existing test patterns. Verified UI handles loading state gracefully.

---
*PR created automatically by Jules for task [16660078908508370159](https://jules.google.com/task/16660078908508370159) started by @dhruvhaldar*