### PR TITLE
⚡ Bolt: Add in-memory caching for parsed period entries

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -237,9 +237,11 @@ export default function HomeScreen() {
       let entries = [];
       
       try {
-        // Bolt Optimization: Use cached PeriodStorage for faster access
-        const existingEntries = await PeriodStorage.getEntries();
-        entries = parseSafePeriodEntries(existingEntries);
+        // Bolt Optimization: Use cached parsed entries directly from storage
+        // This reuses the in-memory cache and avoids redundant JSON parsing/validation
+        const existingEntries = await PeriodStorage.getParsedEntries();
+        // Create a shallow copy to safely mutate
+        entries = [...existingEntries];
       } catch (parseError: any) {
         console.error('🚨 Error retrieving period entries:', parseError instanceof Error ? parseError.message : String(parseError));
         entries = [];

--- a/hooks/usePeriodEntries.ts
+++ b/hooks/usePeriodEntries.ts
@@ -1,31 +1,29 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { AppState, AppStateStatus } from 'react-native';
 import { PeriodStorage } from '@/utils/storage';
-import { parseSafePeriodEntries } from '@/utils/validation';
 import { useFocusEffect } from 'expo-router';
 import { HistoryEntry } from '@/components/HistoryItem';
 
 export function usePeriodEntries() {
   const [entries, setEntries] = useState<HistoryEntry[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-  // Ref to store the raw string of the last fetched entries to avoid unnecessary re-parsing and re-renders
-  const lastFetchedEntriesRef = useRef<string | null>(null);
+  // Ref to store the reference of the last fetched entries array to avoid unnecessary re-renders
+  const lastFetchedEntriesRef = useRef<any[] | null>(null);
 
   const fetchEntries = useCallback(async () => {
     setIsLoading(true);
     try {
-      // Bolt Optimization: Use cached PeriodStorage to avoid disk reads on tab switch
-      const storedEntries = await PeriodStorage.getEntries();
+      // Bolt Optimization: Use cached parsed entries from storage directly
+      // This skips JSON parsing and validation if the data hasn't changed
+      const parsedEntries = await PeriodStorage.getParsedEntries();
 
-      // Optimization: Only parse and update state if the data has actually changed
-      if (storedEntries === lastFetchedEntriesRef.current) {
+      // Optimization: Only update state if the array reference has changed
+      if (parsedEntries === lastFetchedEntriesRef.current) {
         setIsLoading(false);
         return;
       }
-      lastFetchedEntriesRef.current = storedEntries;
+      lastFetchedEntriesRef.current = parsedEntries;
 
-      // Security: Safely parse entries to prevent DoS/Crashes if storage is corrupted
-      const parsedEntries = parseSafePeriodEntries(storedEntries);
       setEntries(parsedEntries);
     } catch (error: any) {
       console.error('Error fetching period entries:', error instanceof Error ? error.message : String(error));

--- a/utils/__tests__/storage.test.ts
+++ b/utils/__tests__/storage.test.ts
@@ -1,6 +1,8 @@
 import { PeriodStorage, initializeStorageProtection } from '../storage';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { AppState } from 'react-native';
+// Mock validation to avoid strict schema checks in storage tests
+import { parseSafePeriodEntries } from '../validation';
 
 // Mock AsyncStorage
 jest.mock('@react-native-async-storage/async-storage', () => ({
@@ -13,6 +15,11 @@ jest.mock('react-native', () => ({
   AppState: {
     addEventListener: jest.fn(),
   },
+}));
+
+// Mock validation
+jest.mock('../validation', () => ({
+  parseSafePeriodEntries: jest.fn(),
 }));
 
 describe('PeriodStorage', () => {
@@ -74,6 +81,47 @@ describe('PeriodStorage', () => {
     const result = await PeriodStorage.getEntries();
     expect(result).toBe(newData);
     expect(AsyncStorage.getItem).not.toHaveBeenCalled(); // Should not call getItem if cache is hit
+  });
+
+  it('getParsedEntries caches parsed result and returns reference', async () => {
+    const rawData = '["test"]';
+    const parsedData = ['test'];
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(rawData);
+    (parseSafePeriodEntries as jest.Mock).mockReturnValue(parsedData);
+
+    // First call: gets string, parses it
+    const result1 = await PeriodStorage.getParsedEntries();
+    expect(result1).toBe(parsedData);
+    expect(AsyncStorage.getItem).toHaveBeenCalledTimes(1);
+    expect(parseSafePeriodEntries).toHaveBeenCalledWith(rawData);
+
+    // Second call: should return cached array reference without re-parsing
+    const result2 = await PeriodStorage.getParsedEntries();
+    expect(result2).toBe(result1); // Reference equality!
+    expect(parseSafePeriodEntries).toHaveBeenCalledTimes(1);
+  });
+
+  it('saveEntries invalidates parsed cache', async () => {
+    const rawData = '["old"]';
+    const parsedDataOld = ['old'];
+    const parsedDataNew = ['new'];
+
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(rawData);
+    (parseSafePeriodEntries as jest.Mock).mockReturnValueOnce(parsedDataOld).mockReturnValueOnce(parsedDataNew);
+
+    // Populate cache
+    await PeriodStorage.getParsedEntries();
+    expect(parseSafePeriodEntries).toHaveBeenCalledTimes(1);
+
+    // Save new data
+    const newData = '["new"]';
+    await PeriodStorage.saveEntries(newData);
+
+    // getParsedEntries should re-parse
+    const result = await PeriodStorage.getParsedEntries();
+    expect(result).toBe(parsedDataNew);
+    expect(parseSafePeriodEntries).toHaveBeenCalledTimes(2);
+    expect(parseSafePeriodEntries).toHaveBeenCalledWith(newData);
   });
 });
 

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -1,5 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { AppState, AppStateStatus } from 'react-native';
+import { parseSafePeriodEntries } from './validation';
 
 /**
  * PeriodStorage
@@ -8,6 +9,8 @@ import { AppState, AppStateStatus } from 'react-native';
  */
 
 let cachedEntries: string | null = null;
+// Bolt Optimization: Cache parsed entries to avoid repeated JSON parsing and validation loops
+let cachedParsedEntries: any[] | null = null;
 // Bolt Optimization: Track pending promise to deduplicate concurrent requests
 let pendingGetEntriesPromise: Promise<string | null> | null = null;
 
@@ -43,11 +46,31 @@ export const PeriodStorage = {
   },
 
   /**
+   * Retrieves parsed period entries from cache, or parses them if needed.
+   * This avoids the O(N) cost of validation and JSON parsing on repeated access.
+   */
+  async getParsedEntries(): Promise<any[]> {
+    // Ensure the raw string cache is populated
+    await this.getEntries();
+
+    if (cachedParsedEntries !== null) {
+      return cachedParsedEntries;
+    }
+
+    // Parse and cache the result
+    // parseSafePeriodEntries handles null/empty strings gracefully returning []
+    cachedParsedEntries = parseSafePeriodEntries(cachedEntries);
+    return cachedParsedEntries;
+  },
+
+  /**
    * Saves period entries to AsyncStorage and updates the cache.
    * Ensures subsequent reads are consistent.
    */
   async saveEntries(entriesString: string): Promise<void> {
     cachedEntries = entriesString;
+    // Invalidate parsed cache as data has changed
+    cachedParsedEntries = null;
     await AsyncStorage.setItem('periodEntries', entriesString);
   },
 
@@ -56,6 +79,7 @@ export const PeriodStorage = {
    */
   clearCache() {
     cachedEntries = null;
+    cachedParsedEntries = null;
     pendingGetEntriesPromise = null;
   }
 };


### PR DESCRIPTION
This PR introduces an in-memory caching layer for parsed period entries within `PeriodStorage`. 

**Why:**
Currently, `PeriodStorage` only caches the raw JSON string. Every time `usePeriodEntries` runs (e.g., on tab switch or app resume) or when `logPeriod` is called, the application:
1.  Retrieves the JSON string (fast).
2.  Parses the JSON (slow for large data).
3.  Runs `isValidBackupEntry` on EVERY entry (O(N)), which involves multiple regex checks per entry.

**What:**
-   `PeriodStorage` now maintains a `cachedParsedEntries` variable.
-   `getParsedEntries()` lazily parses and validates the data only when the cache is empty.
-   `saveEntries()` invalidates the parsed cache.
-   `usePeriodEntries` uses `getParsedEntries()` and compares the returned array reference to `lastFetchedEntriesRef`. If the reference is the same, it skips the `setEntries` call, preventing React re-renders.

**Impact:**
-   Reduces main thread blocking during navigation and app resume for users with significant history.
-   Eliminates redundant object creation and garbage collection pressure.
-   Prevents unnecessary re-renders of the `HistoryScreen`, `InsightsScreen`, and `HomeScreen` when data hasn't changed.


---
*PR created automatically by Jules for task [2723775093724026257](https://jules.google.com/task/2723775093724026257) started by @dhruvhaldar*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized entry data retrieval by implementing in-memory caching for parsed entries, eliminating redundant parsing and validation steps to improve overall performance
  * Enhanced data consistency by ensuring cached parsed entries are automatically invalidated when entries are saved or cleared

* **Tests**
  * Added comprehensive tests for parsed entries caching behavior, cache invalidation scenarios, and validation flows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->