### PR TITLE
🎨 Palette: Visual Anchors for History Items

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2025-10-29 - Tappable Settings Rows
 **Learning:** Small toggle switches have poor touch targets, frustrating users and failing accessibility guidelines for motor impairments.
 **Action:** Wrap the entire settings row (label + switch) in a `TouchableOpacity`. Apply `accessibilityRole="switch"` to the wrapper and hide the internal switch from accessibility (`accessible={false}`, `pointerEvents="none"`), creating a large, single touch target that behaves natively.
+
+## 2025-10-30 - Visual Anchors in Lists
+**Learning:** Dense lists of text-based key-value pairs are difficult to scan quickly, leading to increased cognitive load for sighted users.
+**Action:** Prepend consistent icons (emojis) to labels to serve as visual anchors and conditionally render optional fields to reduce visual clutter, improving scannability without compromising accessibility.

--- a/components/HistoryItem.tsx
+++ b/components/HistoryItem.tsx
@@ -81,12 +81,14 @@ const HistoryItem = React.memo(function HistoryItem({ item, onDelete, textColor,
           accessible={true}
           accessibilityLabel={accessibilityLabel}
         >
-          <Text style={{ color: textColor }}>Last Period: {lastPeriodDate}</Text>
-          <Text style={{ color: textColor }}>Cycle Length: {item.cycleLength} days</Text>
-          <Text style={{ color: textColor }}>Symptoms: {symptomsString}</Text>
-          <Text style={{ color: textColor }}>Flow: {item.selectedFlow || 'Not logged'}</Text>
-          <Text style={{ color: textColor }}>Notes: {item.notes}</Text>
-          <Text style={{ color: textColor }}>Log Date: {logDate}</Text>
+          <Text style={{ color: textColor }}>🗓️ Last Period: {lastPeriodDate}</Text>
+          <Text style={{ color: textColor }}>🔄 Cycle Length: {item.cycleLength} days</Text>
+          <Text style={{ color: textColor }}>🤒 Symptoms: {symptomsString || 'None'}</Text>
+          <Text style={{ color: textColor }}>🩸 Flow: {item.selectedFlow || 'Not logged'}</Text>
+          {item.notes ? (
+            <Text style={{ color: textColor }}>📝 Notes: {item.notes}</Text>
+          ) : null}
+          <Text style={{ color: textColor }}>🕒 Log Date: {logDate}</Text>
         </View>
 
         <TouchableOpacity

--- a/components/__tests__/HistoryItem-test.tsx
+++ b/components/__tests__/HistoryItem-test.tsx
@@ -32,14 +32,42 @@ describe('HistoryItem', () => {
       />
     );
 
-    // Verify individual texts are present (current behavior)
+    // Verify individual texts are present with icons
     // Note: 'Sept' is observed in test output for September in en-GB locale in this environment
-    expect(getByText(/Last Period: 25 Sept? 2023/)).toBeTruthy();
-    expect(getByText(/Cycle Length: 28 days/)).toBeTruthy();
-    expect(getByText(/Symptoms: Cramps, Headache/)).toBeTruthy();
-    expect(getByText(/Flow: Medium/)).toBeTruthy();
-    expect(getByText(/Notes: Feeling okay/)).toBeTruthy();
-    expect(getByText(/Log Date: 1 Oct 2023/)).toBeTruthy();
+    expect(getByText(/🗓️ Last Period: 25 Sept? 2023/)).toBeTruthy();
+    expect(getByText(/🔄 Cycle Length: 28 days/)).toBeTruthy();
+    expect(getByText(/🤒 Symptoms: Cramps, Headache/)).toBeTruthy();
+    expect(getByText(/🩸 Flow: Medium/)).toBeTruthy();
+    expect(getByText(/📝 Notes: Feeling okay/)).toBeTruthy();
+    expect(getByText(/🕒 Log Date: 1 Oct 2023/)).toBeTruthy();
+  });
+
+  it('hides notes when empty', () => {
+    const entryWithoutNotes = { ...mockEntry, notes: '' };
+    const { queryByText } = render(
+      <HistoryItem
+        item={entryWithoutNotes}
+        onDelete={mockOnDelete}
+        textColor="#000"
+        deleteIconColor="#f00"
+      />
+    );
+
+    expect(queryByText(/📝 Notes:/)).toBeNull();
+  });
+
+  it('shows "None" for empty symptoms', () => {
+    const entryWithoutSymptoms = { ...mockEntry, selectedSymptoms: [] };
+    const { getByText } = render(
+      <HistoryItem
+        item={entryWithoutSymptoms}
+        onDelete={mockOnDelete}
+        textColor="#000"
+        deleteIconColor="#f00"
+      />
+    );
+
+    expect(getByText(/🤒 Symptoms: None/)).toBeTruthy();
   });
 
   it('groups details into a single accessible element', () => {


### PR DESCRIPTION
This PR enhances the `HistoryItem` component by adding visual anchors (emojis) to data labels, making the list easier to scan. It also improves the visual cleanliness by hiding the "Notes" field when no notes are present and explicitly stating "None" for empty symptoms. These changes add a touch of delight and clarity to the user's history log.

---
*PR created automatically by Jules for task [6060469574737232261](https://jules.google.com/task/6060469574737232261) started by @dhruvhaldar*