### PR TITLE
🎨 Palette: Add focus state to ChatInput

### DIFF
--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -1,5 +1,5 @@
 import React, { useState, forwardRef, useImperativeHandle } from 'react';
-import { TextInput, View, TouchableOpacity, ActivityIndicator, StyleSheet } from 'react-native';
+import { TextInput, View, TouchableOpacity, ActivityIndicator, StyleSheet, Platform } from 'react-native';
 import { ThemedText } from './ThemedText';
 import { MAX_INPUT_LENGTH } from '@/utils/validation';
 
@@ -18,6 +18,7 @@ interface ChatInputProps {
 
 export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(({ onSubmit, isLoading, textColor, placeholderTextColor }, ref) => {
   const [text, setText] = useState('');
+  const [isFocused, setIsFocused] = useState(false);
 
   useImperativeHandle(ref, () => ({
     getText: () => text,
@@ -38,13 +39,27 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(({ onSubmit
   return (
     <View style={styles.inputContainer}>
         <TextInput
-            style={[styles.input, { color: textColor }]}
+            style={[
+                styles.input,
+                {
+                    color: textColor,
+                    borderWidth: isFocused ? 2 : 1,
+                    ...Platform.select({
+                        web: {
+                            outlineStyle: 'none'
+                        }
+                    })
+                }
+            ]}
             placeholder="Ask a menstrual health question..."
             placeholderTextColor={placeholderTextColor}
             value={text}
             onChangeText={setText}
+            onFocus={() => setIsFocused(true)}
+            onBlur={() => setIsFocused(false)}
             editable={!isLoading}
             accessibilityLabel="Ask a menstrual health question"
+            accessibilityHint="Double tap to enter text. Submit sends the question."
             returnKeyType="send"
             onSubmitEditing={handleSubmit}
             maxLength={MAX_INPUT_LENGTH}
@@ -62,6 +77,8 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(({ onSubmit
     </View>
   );
 });
+
+ChatInput.displayName = 'ChatInput';
 
 const styles = StyleSheet.create({
   inputContainer: {

--- a/components/__tests__/ChatInput-test.tsx
+++ b/components/__tests__/ChatInput-test.tsx
@@ -81,4 +81,52 @@ describe('ChatInput', () => {
       const button = getByRole('button', { name: 'Send question to AI assistant' });
       expect(button.props.accessibilityState.disabled).toBe(true);
   });
+
+  it('has correct accessibility hint', () => {
+    const { getByPlaceholderText } = render(
+      <ChatInput
+        onSubmit={mockOnSubmit}
+        isLoading={false}
+        textColor="#000"
+        placeholderTextColor="#666"
+      />
+    );
+    const input = getByPlaceholderText('Ask a menstrual health question...');
+    expect(input.props.accessibilityHint).toBe('Double tap to enter text. Submit sends the question.');
+  });
+
+  it('changes border width on focus', () => {
+    const { getByPlaceholderText } = render(
+      <ChatInput
+        onSubmit={mockOnSubmit}
+        isLoading={false}
+        textColor="#000"
+        placeholderTextColor="#666"
+      />
+    );
+    const input = getByPlaceholderText('Ask a menstrual health question...');
+
+    // Initial state (blurred)
+    // Check if flat style object contains borderWidth: 1
+    // Note: styles are often flattened in tests, checking the style array/object
+    // Depending on how style prop is constructed, it might be an array.
+    // The component uses [styles.input, { color, borderWidth }]
+    // So the last element should contain the dynamic borderWidth.
+
+    const flatStyle = [input.props.style].flat();
+    const dynamicStyle = flatStyle[flatStyle.length - 1];
+    expect(dynamicStyle.borderWidth).toBe(1);
+
+    // Focus
+    fireEvent(input, 'focus');
+    const focusedStyle = [input.props.style].flat();
+    const focusedDynamicStyle = focusedStyle[focusedStyle.length - 1];
+    expect(focusedDynamicStyle.borderWidth).toBe(2);
+
+    // Blur
+    fireEvent(input, 'blur');
+    const blurredStyle = [input.props.style].flat();
+    const blurredDynamicStyle = blurredStyle[blurredStyle.length - 1];
+    expect(blurredDynamicStyle.borderWidth).toBe(1);
+  });
 });


### PR DESCRIPTION
Added visual focus indicator (border width) and accessibility hint to ChatInput.
Fixed web outline clashing with custom border by setting outlineStyle to none.
Added unit tests for new functionality.

---
*PR created automatically by Jules for task [744333833816676698](https://jules.google.com/task/744333833816676698) started by @dhruvhaldar*