### PR TITLE
🛡️ Sentinel: Enforce HTTPS for external links

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -42,3 +42,8 @@
 **Vulnerability:** The input validation relied on a deny-list (`SUSPICIOUS_PATTERNS`) that missed critical XSS vectors like `<svg>` tags (which can execute scripts) and generic event handlers (only specific ones like `onload` were blocked).
 **Learning:** Deny-lists are inherently fragile and require constant maintenance. Attackers can bypass them using obscure HTML tags or attributes.
 **Prevention:** Significantly expanded the deny-list to include risky tags (`<svg>`, `<style>`, `<base>`) and implemented a regex that matches a broad class of event handlers (`on[event]=`) rather than a hardcoded list. Additionally, added input length limits (`maxLength`) on UI components as defense-in-depth against Denial of Service.
+
+## 2026-03-12 - Mixed Content (HTTP) Allowed in External Links
+**Vulnerability:** The `isValidExternalUrl` utility allowed `http://` URLs, permitting unencrypted communication and potential Man-in-the-Middle (MitM) attacks where the destination page could be spoofed or traffic intercepted.
+**Learning:** While `http` seems harmless for external links, it degrades the security posture of the application and exposes users to network-level attacks. In 2026, HTTPS should be mandatory.
+**Prevention:** Updated validation logic to enforce `https://` scheme exclusively for all external links.

--- a/utils/__tests__/validation.test.ts
+++ b/utils/__tests__/validation.test.ts
@@ -237,8 +237,8 @@ describe('Validation Utils', () => {
       expect(isValidExternalUrl('https://example.com')).toBe(true);
     });
 
-    it('accepts valid http url', () => {
-      expect(isValidExternalUrl('http://example.com')).toBe(true);
+    it('rejects http url (insecure)', () => {
+      expect(isValidExternalUrl('http://example.com')).toBe(false);
     });
 
     it('rejects javascript protocol', () => {

--- a/utils/validation.ts
+++ b/utils/validation.ts
@@ -193,8 +193,8 @@ export const parseSafePeriodEntries = (json: string | null): any[] => {
 };
 
 /**
- * Validates if a URL is safe to open (HTTP/HTTPS only).
- * Rejects potentially dangerous schemes like javascript:, file:, vbscript:.
+ * Validates if a URL is safe to open (HTTPS only).
+ * Rejects potentially dangerous schemes like javascript:, file:, vbscript: and insecure http:.
  * @param url The URL to check.
  * @returns True if the URL is safe.
  */
@@ -202,6 +202,6 @@ export const isValidExternalUrl = (url: string): boolean => {
   if (!url) return false;
   // Trim whitespace
   const trimmedUrl = url.trim();
-  // Check if it starts with http:// or https:// (case insensitive)
-  return /^https?:\/\//i.test(trimmedUrl);
+  // Check if it starts with https:// (case insensitive)
+  return /^https:\/\//i.test(trimmedUrl);
 };


### PR DESCRIPTION
Enforced HTTPS for all external links to improve security. Updated validation logic, tests, and added a Sentinel Journal entry.

---
*PR created automatically by Jules for task [7119363260123120148](https://jules.google.com/task/7119363260123120148) started by @dhruvhaldar*