### PR TITLE
feat(ChatInput): add clear button for better UX

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -17,3 +17,7 @@
 ## 2025-10-30 - Visual Anchors in Lists
 **Learning:** Dense lists of text-based key-value pairs are difficult to scan quickly, leading to increased cognitive load for sighted users.
 **Action:** Prepend consistent icons (emojis) to labels to serve as visual anchors and conditionally render optional fields to reduce visual clutter, improving scannability without compromising accessibility.
+
+## 2025-11-01 - Input Clear Button Pattern
+**Learning:** Long text inputs (like chat or notes) are tedious to clear via backspace, especially on mobile.
+**Action:** Implement an absolute-positioned "Clear" button inside the input container that only appears when text is present, ensuring it clears content and refocuses the field for immediate re-typing.

--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -1,6 +1,7 @@
-import React, { useState, forwardRef, useImperativeHandle } from 'react';
+import React, { useState, forwardRef, useImperativeHandle, useRef, useCallback } from 'react';
 import { TextInput, View, TouchableOpacity, ActivityIndicator, StyleSheet, Platform } from 'react-native';
 import { ThemedText } from './ThemedText';
+import { IconSymbol } from '@/components/ui/IconSymbol';
 import { MAX_INPUT_LENGTH } from '@/utils/validation';
 
 export interface ChatInputHandle {
@@ -19,6 +20,7 @@ interface ChatInputProps {
 export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(({ onSubmit, isLoading, textColor, placeholderTextColor }, ref) => {
   const [text, setText] = useState('');
   const [isFocused, setIsFocused] = useState(false);
+  const inputRef = useRef<TextInput>(null);
 
   useImperativeHandle(ref, () => ({
     getText: () => text,
@@ -36,34 +38,55 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(({ onSubmit
     }
   };
 
+  const handleClear = useCallback(() => {
+    setText('');
+    inputRef.current?.focus();
+  }, []);
+
   return (
     <View style={styles.inputContainer}>
-        <TextInput
-            style={[
-                styles.input,
-                {
-                    color: textColor,
-                    borderWidth: isFocused ? 2 : 1,
-                    ...Platform.select({
-                        web: {
-                            outlineStyle: 'none'
-                        }
-                    })
-                }
-            ]}
-            placeholder="Ask a menstrual health question..."
-            placeholderTextColor={placeholderTextColor}
-            value={text}
-            onChangeText={setText}
-            onFocus={() => setIsFocused(true)}
-            onBlur={() => setIsFocused(false)}
-            editable={!isLoading}
-            accessibilityLabel="Ask a menstrual health question"
-            accessibilityHint="Double tap to enter text. Submit sends the question."
-            returnKeyType="send"
-            onSubmitEditing={handleSubmit}
-            maxLength={MAX_INPUT_LENGTH}
-        />
+        <View style={styles.inputWrapper}>
+          <TextInput
+              ref={inputRef}
+              style={[
+                  styles.input,
+                  {
+                      color: textColor,
+                      borderWidth: isFocused ? 2 : 1,
+                      paddingRight: 40, // Add padding for clear button
+                      ...Platform.select({
+                          web: {
+                              outlineStyle: 'none'
+                          }
+                      })
+                  }
+              ]}
+              placeholder="Ask a menstrual health question..."
+              placeholderTextColor={placeholderTextColor}
+              value={text}
+              onChangeText={setText}
+              onFocus={() => setIsFocused(true)}
+              onBlur={() => setIsFocused(false)}
+              editable={!isLoading}
+              accessibilityLabel="Ask a menstrual health question"
+              accessibilityHint="Double tap to enter text. Submit sends the question."
+              returnKeyType="send"
+              onSubmitEditing={handleSubmit}
+              maxLength={MAX_INPUT_LENGTH}
+          />
+          {text.length > 0 && !isLoading && (
+            <TouchableOpacity
+              style={styles.clearButton}
+              onPress={handleClear}
+              accessibilityLabel="Clear question"
+              accessibilityRole="button"
+              hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+            >
+              <IconSymbol name="xmark.circle.fill" size={20} color={placeholderTextColor} />
+            </TouchableOpacity>
+          )}
+        </View>
+
         <TouchableOpacity
             style={[styles.button, isButtonDisabled && styles.buttonDisabled]}
             onPress={handleSubmit}
@@ -84,14 +107,24 @@ const styles = StyleSheet.create({
   inputContainer: {
     marginTop: 10,
   },
+  inputWrapper: {
+    position: 'relative',
+    marginBottom: 15,
+  },
   input: {
     height: 60,
     borderColor: '#E63946',
     borderWidth: 1,
     paddingHorizontal: 15,
     borderRadius: 8,
-    marginBottom: 15,
     fontSize: 16,
+    marginBottom: 0, // Reset default margin since it's on wrapper now
+  },
+  clearButton: {
+    position: 'absolute',
+    right: 10,
+    top: 15, // Vertically centered (60 - 30) / 2
+    padding: 5,
   },
   button: {
     backgroundColor: '#E63946',

--- a/components/__tests__/ChatInput-test.tsx
+++ b/components/__tests__/ChatInput-test.tsx
@@ -106,27 +106,52 @@ describe('ChatInput', () => {
     );
     const input = getByPlaceholderText('Ask a menstrual health question...');
 
-    // Initial state (blurred)
-    // Check if flat style object contains borderWidth: 1
-    // Note: styles are often flattened in tests, checking the style array/object
-    // Depending on how style prop is constructed, it might be an array.
-    // The component uses [styles.input, { color, borderWidth }]
-    // So the last element should contain the dynamic borderWidth.
-
     const flatStyle = [input.props.style].flat();
     const dynamicStyle = flatStyle[flatStyle.length - 1];
     expect(dynamicStyle.borderWidth).toBe(1);
 
-    // Focus
     fireEvent(input, 'focus');
     const focusedStyle = [input.props.style].flat();
     const focusedDynamicStyle = focusedStyle[focusedStyle.length - 1];
     expect(focusedDynamicStyle.borderWidth).toBe(2);
 
-    // Blur
     fireEvent(input, 'blur');
     const blurredStyle = [input.props.style].flat();
     const blurredDynamicStyle = blurredStyle[blurredStyle.length - 1];
     expect(blurredDynamicStyle.borderWidth).toBe(1);
+  });
+
+  it('shows clear button when text is present and clears it on press', () => {
+    const { getByRole, queryByRole, getByPlaceholderText } = render(
+      <ChatInput
+        onSubmit={mockOnSubmit}
+        isLoading={false}
+        textColor="#000"
+        placeholderTextColor="#666"
+      />
+    );
+    const input = getByPlaceholderText('Ask a menstrual health question...');
+
+    // Initially clear button should not be present
+    expect(queryByRole('button', { name: 'Clear question' })).toBeNull();
+
+    // Type text
+    fireEvent.changeText(input, 'Some text');
+
+    // Clear button should appear
+    const clearButton = getByRole('button', { name: 'Clear question' });
+    expect(clearButton).toBeTruthy();
+
+    // Press clear button
+    fireEvent.press(clearButton);
+
+    // Text should be cleared
+    // Note: in React Native Testing Library, verifying value prop might need re-query or check state effect
+    // But since fireEvent.press triggers state update, render should re-render.
+    // However, `input` variable is a reference to the element node from previous render.
+    // We should probably check input.props.value if it's updated.
+    // Or check that button disappeared.
+
+    expect(queryByRole('button', { name: 'Clear question' })).toBeNull();
   });
 });


### PR DESCRIPTION
Added a "Clear" button to the ChatInput component to allow users to easily clear their message. The button only appears when text is present and disappears after clearing. Includes accessibility support and tests. Verified with Playwright.

---
*PR created automatically by Jules for task [16679367601829933215](https://jules.google.com/task/16679367601829933215) started by @dhruvhaldar*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a clear button to the chat input that appears when text is entered, allowing users to quickly clear content and refocus the field.

* **Tests**
  * Added test coverage for the clear button functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->