### PR TITLE
🎨 Palette: Reduce visual noise in History items

### DIFF
--- a/components/HistoryItem.tsx
+++ b/components/HistoryItem.tsx
@@ -1,7 +1,8 @@
 import React, { useMemo } from 'react';
-import { StyleSheet, View, Text, TouchableOpacity } from 'react-native';
+import { StyleSheet, View, TouchableOpacity } from 'react-native';
 import { IconSymbol } from '@/components/ui/IconSymbol';
 import { formatDate } from '@/utils/dateFormatter';
+import { ThemedText } from '@/components/ThemedText';
 
 // Define the shape of an entry based on usage in history.tsx
 export interface HistoryEntry {
@@ -70,7 +71,12 @@ const HistoryItem = React.memo(function HistoryItem({ item, onDelete, textColor,
   }, [item.selectedSymptoms]);
 
   const accessibilityLabel = useMemo(() => {
-    return `Entry for ${lastPeriodDate}. Cycle Length: ${item.cycleLength} days. Symptoms: ${symptomsString || 'None'}. Flow: ${item.selectedFlow || 'Not logged'}. Notes: ${item.notes || 'None'}. Log Date: ${logDate}`;
+    let label = `Entry for ${lastPeriodDate}. Cycle Length: ${item.cycleLength} days.`;
+    if (symptomsString) label += ` Symptoms: ${symptomsString}.`;
+    if (item.selectedFlow) label += ` Flow: ${item.selectedFlow}.`;
+    if (item.notes) label += ` Notes: ${item.notes}.`;
+    label += ` Log Date: ${logDate}`;
+    return label;
   }, [lastPeriodDate, item.cycleLength, symptomsString, item.selectedFlow, item.notes, logDate]);
 
   return (
@@ -81,14 +87,18 @@ const HistoryItem = React.memo(function HistoryItem({ item, onDelete, textColor,
           accessible={true}
           accessibilityLabel={accessibilityLabel}
         >
-          <Text style={{ color: textColor }}>🗓️ Last Period: {lastPeriodDate}</Text>
-          <Text style={{ color: textColor }}>🔄 Cycle Length: {item.cycleLength} days</Text>
-          <Text style={{ color: textColor }}>🤒 Symptoms: {symptomsString || 'None'}</Text>
-          <Text style={{ color: textColor }}>🩸 Flow: {item.selectedFlow || 'Not logged'}</Text>
-          {item.notes ? (
-            <Text style={{ color: textColor }}>📝 Notes: {item.notes}</Text>
+          <ThemedText style={{ color: textColor }}>🗓️ Last Period: {lastPeriodDate}</ThemedText>
+          <ThemedText style={{ color: textColor }}>🔄 Cycle Length: {item.cycleLength} days</ThemedText>
+          {symptomsString ? (
+             <ThemedText style={{ color: textColor }}>🤒 Symptoms: {symptomsString}</ThemedText>
           ) : null}
-          <Text style={{ color: textColor }}>🕒 Log Date: {logDate}</Text>
+          {item.selectedFlow ? (
+             <ThemedText style={{ color: textColor }}>🩸 Flow: {item.selectedFlow}</ThemedText>
+          ) : null}
+          {item.notes ? (
+            <ThemedText style={{ color: textColor }}>📝 Notes: {item.notes}</ThemedText>
+          ) : null}
+          <ThemedText style={{ color: textColor }}>🕒 Log Date: {logDate}</ThemedText>
         </View>
 
         <TouchableOpacity

--- a/components/__tests__/HistoryItem-test.tsx
+++ b/components/__tests__/HistoryItem-test.tsx
@@ -56,9 +56,9 @@ describe('HistoryItem', () => {
     expect(queryByText(/📝 Notes:/)).toBeNull();
   });
 
-  it('shows "None" for empty symptoms', () => {
+  it('hides "Symptoms" row when empty', () => {
     const entryWithoutSymptoms = { ...mockEntry, selectedSymptoms: [] };
-    const { getByText } = render(
+    const { queryByText } = render(
       <HistoryItem
         item={entryWithoutSymptoms}
         onDelete={mockOnDelete}
@@ -67,7 +67,21 @@ describe('HistoryItem', () => {
       />
     );
 
-    expect(getByText(/🤒 Symptoms: None/)).toBeTruthy();
+    expect(queryByText(/🤒 Symptoms:/)).toBeNull();
+  });
+
+  it('hides "Flow" row when null', () => {
+    const entryWithoutFlow = { ...mockEntry, selectedFlow: null };
+    const { queryByText } = render(
+      <HistoryItem
+        item={entryWithoutFlow}
+        onDelete={mockOnDelete}
+        textColor="#000"
+        deleteIconColor="#f00"
+      />
+    );
+
+    expect(queryByText(/🩸 Flow:/)).toBeNull();
   });
 
   it('groups details into a single accessible element', () => {
@@ -84,6 +98,26 @@ describe('HistoryItem', () => {
     // Using regex to handle potential date format differences (Sep vs Sept)
     const expectedLabelRegex = /Entry for 25 Sept? 2023\. Cycle Length: 28 days\. Symptoms: Cramps, Headache\. Flow: Medium\. Notes: Feeling okay\. Log Date: 1 Oct 2023/;
 
+    expect(getByLabelText(expectedLabelRegex)).toBeTruthy();
+  });
+
+  it('generates concise accessibility label when fields are missing', () => {
+    const sparseEntry = {
+      ...mockEntry,
+      selectedSymptoms: [],
+      selectedFlow: null,
+      notes: '',
+    };
+    const { getByLabelText } = render(
+      <HistoryItem
+        item={sparseEntry}
+        onDelete={mockOnDelete}
+        textColor="#000"
+        deleteIconColor="#f00"
+      />
+    );
+
+    const expectedLabelRegex = /Entry for 25 Sept? 2023\. Cycle Length: 28 days\. Log Date: 1 Oct 2023/;
     expect(getByLabelText(expectedLabelRegex)).toBeTruthy();
   });
 });


### PR DESCRIPTION
Palette UX Improvement:
- **What:** Modified `HistoryItem` to hide "Symptoms" and "Flow" rows when they are empty/null.
- **Why:** To reduce visual noise and make the history list easier to scan. It also improves accessibility by removing redundant "None" announcements.
- **Before:** "Symptoms: None", "Flow: Not logged" displayed for every empty entry.
- **After:** Only relevant data is shown. "Log Date" is retained as metadata.
- **Verification:** Updated unit tests and verified with Playwright screenshot.

---
*PR created automatically by Jules for task [8382121826543053028](https://jules.google.com/task/8382121826543053028) started by @dhruvhaldar*