### PR TITLE
🎨 Palette: Add fertility status to prediction summary

### DIFF
--- a/components/PredictionSummary.tsx
+++ b/components/PredictionSummary.tsx
@@ -105,46 +105,76 @@ const PredictionSummary = React.memo(function PredictionSummary({
     );
   }, [predictedPeriods, periodDuration, predictedHeadingColor, textColor]);
 
-  const ovulationSection = useMemo(() => (
-    <ThemedView style={styles.section}>
-      <ThemedText
-        type="subtitle"
-        style={{ color: predictedHeadingColor, marginBottom: 10 }}
-      >
-        Predicted Ovulations
-      </ThemedText>
-      {predictedOvulations.map((date, index) => {
-        // Calculate fertile window start (5 days before ovulation)
-        const fertileWindowStart = new Date(date);
-        fertileWindowStart.setDate(fertileWindowStart.getDate() - 5);
+  const ovulationSection = useMemo(() => {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const todayTime = today.getTime();
 
-        return (
-          <ThemedView
-            key={index}
-            style={[
-              styles.predictionItem,
-              { borderColor: textColor, borderWidth: 1 }
-            ]}
-            accessible={true}
-            accessibilityLabel={`Ovulation on ${formatDate(date, DateFormats.MonthDay)}. Fertile window from ${formatDate(fertileWindowStart, DateFormats.MonthDay)} to ${formatDate(date, DateFormats.MonthDay)}`}
-          >
-            <ThemedText style={{ color: textColor }}>
-              Ovulation: {formatDate(date, DateFormats.MonthDay)}
-            </ThemedText>
-            <ThemedText
-              style={{
-                color: textColor,
-                fontSize: 12,
-                marginTop: 5
-              }}
+    return (
+      <ThemedView style={styles.section}>
+        <ThemedText
+          type="subtitle"
+          style={{ color: predictedHeadingColor, marginBottom: 10 }}
+        >
+          Predicted Ovulations
+        </ThemedText>
+        {predictedOvulations.map((date, index) => {
+          // Calculate fertile window start (5 days before ovulation)
+          const fertileWindowStart = new Date(date);
+          fertileWindowStart.setDate(fertileWindowStart.getDate() - 5);
+
+          // Calculate days remaining to ovulation
+          const target = new Date(date);
+          target.setHours(0, 0, 0, 0);
+          const diffTime = target.getTime() - todayTime;
+          const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+
+          let statusText = '';
+          let statusLabel = '';
+          let statusColor = textColor;
+
+          if (diffDays === 0) {
+            statusText = ' (Today! 🥚)';
+            statusLabel = ', Today is ovulation day';
+            statusColor = '#E63946'; // Red/Warning color for importance
+          } else if (diffDays > 0 && diffDays <= 5) {
+            statusText = ' (High Chance 🌟)';
+            statusLabel = ', High chance of fertility';
+            statusColor = '#2a9d8f'; // Green/Success color for fertility
+          } else if (diffDays > 5) {
+            statusText = ` (in ${diffDays} days)`;
+            statusLabel = `, in ${diffDays} days`;
+          }
+
+          return (
+            <ThemedView
+              key={index}
+              style={[
+                styles.predictionItem,
+                { borderColor: textColor, borderWidth: 1 }
+              ]}
+              accessible={true}
+              accessibilityLabel={`Ovulation on ${formatDate(date, DateFormats.MonthDay)}${statusLabel}. Fertile window from ${formatDate(fertileWindowStart, DateFormats.MonthDay)} to ${formatDate(date, DateFormats.MonthDay)}`}
             >
-              Fertile Window: {formatDate(fertileWindowStart, DateFormats.MonthDay)} - {formatDate(date, DateFormats.MonthDay)}
-            </ThemedText>
-          </ThemedView>
-        );
-      })}
-    </ThemedView>
-  ), [predictedOvulations, predictedHeadingColor, textColor]); // Independent of periodDuration
+              <ThemedText style={{ color: textColor }}>
+                Ovulation: {formatDate(date, DateFormats.MonthDay)}
+                <ThemedText style={{ fontWeight: 'bold', color: statusColor }}>{statusText}</ThemedText>
+              </ThemedText>
+              <ThemedText
+                style={{
+                  color: textColor,
+                  fontSize: 12,
+                  marginTop: 5
+                }}
+              >
+                Fertile Window: {formatDate(fertileWindowStart, DateFormats.MonthDay)} - {formatDate(date, DateFormats.MonthDay)}
+              </ThemedText>
+            </ThemedView>
+          );
+        })}
+      </ThemedView>
+    );
+  }, [predictedOvulations, predictedHeadingColor, textColor]); // Independent of periodDuration
 
   return (
     <>

--- a/components/__tests__/PredictionSummary-test.tsx
+++ b/components/__tests__/PredictionSummary-test.tsx
@@ -40,8 +40,8 @@ describe('PredictionSummary', () => {
     // Assuming en-GB locale (1 Jan)
     // 27 Dec 2023 to 1 Jan 2024 is 5 days
     const periodLabel = "Predicted period starting 1 Jan, in 5 days, ending 5 Jan";
-    // Ovulation: 14 Jan. Fertile window: 9 Jan - 14 Jan
-    const ovulationLabel = "Ovulation on 14 Jan. Fertile window from 9 Jan to 14 Jan";
+    // Ovulation: 14 Jan. Fertile window: 9 Jan - 14 Jan. Days away: 18 days (27 Dec -> 14 Jan)
+    const ovulationLabel = "Ovulation on 14 Jan, in 18 days. Fertile window from 9 Jan to 14 Jan";
 
     expect(screen.getByLabelText(periodLabel)).toBeTruthy();
     expect(screen.getByLabelText(ovulationLabel)).toBeTruthy();

--- a/components/__tests__/__snapshots__/PredictionSummary-test.tsx.snap
+++ b/components/__tests__/__snapshots__/PredictionSummary-test.tsx.snap
@@ -265,7 +265,7 @@ exports[`PredictionSummary renders correctly 1`] = `
       Predicted Ovulations
     </Text>
     <View
-      accessibilityLabel="Ovulation on 14 Jan. Fertile window from 9 Jan to 14 Jan"
+      accessibilityLabel="Ovulation on 14 Jan, in 18 days. Fertile window from 9 Jan to 14 Jan"
       accessible={true}
       style={
         [
@@ -308,6 +308,29 @@ exports[`PredictionSummary renders correctly 1`] = `
       >
         Ovulation:
         14 Jan
+        <Text
+          style={
+            [
+              {
+                "color": "#1D3557",
+              },
+              {
+                "fontSize": 16,
+                "lineHeight": 24,
+              },
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              {
+                "color": "#000",
+                "fontWeight": "bold",
+              },
+            ]
+          }
+        >
+           (in 18 days)
+        </Text>
       </Text>
       <Text
         style={
@@ -338,7 +361,7 @@ exports[`PredictionSummary renders correctly 1`] = `
       </Text>
     </View>
     <View
-      accessibilityLabel="Ovulation on 14 Feb. Fertile window from 9 Feb to 14 Feb"
+      accessibilityLabel="Ovulation on 14 Feb, in 49 days. Fertile window from 9 Feb to 14 Feb"
       accessible={true}
       style={
         [
@@ -381,6 +404,29 @@ exports[`PredictionSummary renders correctly 1`] = `
       >
         Ovulation:
         14 Feb
+        <Text
+          style={
+            [
+              {
+                "color": "#1D3557",
+              },
+              {
+                "fontSize": 16,
+                "lineHeight": 24,
+              },
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              {
+                "color": "#000",
+                "fontWeight": "bold",
+              },
+            ]
+          }
+        >
+           (in 49 days)
+        </Text>
       </Text>
       <Text
         style={


### PR DESCRIPTION
💡 **What:** Added relative time indicators (e.g., "in X days", "Today") and "High Fertility" status to the Predicted Ovulations section in the home screen.
🎯 **Why:** Users previously had to manually calculate how many days were left until ovulation or if they were currently in their fertile window based on dates alone. This adds immediate, scannable context.
📸 **Before/After:**
*Before:* "Ovulation: 14 Jan"
*After:* "Ovulation: 14 Jan **(in 18 days)**" or "Ovulation: 14 Jan **(High Fertility 🌿)**"
♿ **Accessibility:** The `accessibilityLabel` now includes this status (e.g., "Ovulation on 14 Jan, in 18 days..."), ensuring screen reader users get the same contextual information as sighted users.

---
*PR created automatically by Jules for task [5036376635869148779](https://jules.google.com/task/5036376635869148779) started by @dhruvhaldar*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced ovulation predictions with dynamic status indicators showing whether ovulation is today, high chance, or in N days, complete with visual badges.
  * Improved fertile window display with clearer, separate formatting for better readability.
  * Updated accessibility descriptions for more detailed ovulation timing information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->