### PR TITLE
🎨 Palette: Add upcoming period indicator

### DIFF
--- a/components/PredictionSummary.tsx
+++ b/components/PredictionSummary.tsx
@@ -47,6 +47,7 @@ const PredictionSummary = React.memo(function PredictionSummary({
           let daysRemainingText = '';
           let daysRemainingLabel = '';
           let isLate = false;
+          let isUpcoming = false;
 
           const target = new Date(date);
           target.setHours(0, 0, 0, 0);
@@ -59,7 +60,11 @@ const PredictionSummary = React.memo(function PredictionSummary({
           } else if (diffDays === 1) {
             daysRemainingText = ' (Tomorrow)';
             daysRemainingLabel = ', starting tomorrow';
-          } else if (diffDays > 1) {
+          } else if (diffDays > 1 && diffDays <= 3) {
+            daysRemainingText = ` (in ${diffDays} days)`;
+            daysRemainingLabel = `, coming up in ${diffDays} days`;
+            isUpcoming = true;
+          } else if (diffDays > 3) {
             daysRemainingText = ` (in ${diffDays} days)`;
             daysRemainingLabel = `, in ${diffDays} days`;
           } else if (diffDays < 0) {
@@ -71,10 +76,12 @@ const PredictionSummary = React.memo(function PredictionSummary({
           }
 
           const lateColor = '#E63946';
-          const itemBorderColor = isLate ? lateColor : textColor;
-          const itemBorderWidth = isLate ? 2 : 1;
-          const daysTextColor = isLate ? lateColor : textColor;
-          const backgroundColor = isLate ? 'rgba(230, 57, 70, 0.1)' : undefined;
+          const upcomingColor = '#457B9D';
+
+          const itemBorderColor = isLate ? lateColor : (isUpcoming ? upcomingColor : textColor);
+          const itemBorderWidth = isLate || isUpcoming ? 2 : 1;
+          const daysTextColor = isLate ? lateColor : (isUpcoming ? upcomingColor : textColor);
+          const backgroundColor = isLate ? 'rgba(230, 57, 70, 0.1)' : (isUpcoming ? 'rgba(69, 123, 157, 0.1)' : undefined);
 
           return (
             <ThemedView
@@ -87,8 +94,13 @@ const PredictionSummary = React.memo(function PredictionSummary({
               accessibilityLabel={`Predicted period starting ${formatDate(date, DateFormats.MonthDay)}${daysRemainingLabel}, ending ${formatDate(periodEndDate, DateFormats.MonthDay)}`}
             >
               <View style={styles.row}>
-                {isLate && (
-                  <IconSymbol name="calendar.badge.exclamationmark" size={24} color={lateColor} style={{ marginRight: 10 }} />
+                {(isLate || isUpcoming) && (
+                  <IconSymbol
+                    name={isLate ? "calendar.badge.exclamationmark" : "calendar"}
+                    size={24}
+                    color={isLate ? lateColor : upcomingColor}
+                    style={{ marginRight: 10 }}
+                  />
                 )}
                 <View style={{ flex: 1 }}>
                   <ThemedText style={{ color: textColor }}>

--- a/components/__tests__/PredictionSummary-upcoming-test.tsx
+++ b/components/__tests__/PredictionSummary-upcoming-test.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import PredictionSummary from '../PredictionSummary';
+
+describe('PredictionSummary Upcoming', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2023-12-27T00:00:00.000Z'));
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  it('renders upcoming indicator for periods in 2-3 days', () => {
+    const predictedPeriods = [
+      new Date('2023-12-29T00:00:00.000Z'), // 2 days away
+      new Date('2023-12-30T00:00:00.000Z'), // 3 days away
+      new Date('2023-12-31T00:00:00.000Z'), // 4 days away
+    ];
+
+    render(
+      <PredictionSummary
+        predictedPeriods={predictedPeriods}
+        predictedOvulations={[]}
+        periodDuration="5"
+        textColor="#000"
+        predictedHeadingColor="#123"
+      />
+    );
+
+    // 29 Dec: 2 days away
+    // Label format: `Predicted period starting ${formatDate(date, DateFormats.MonthDay)}${daysRemainingLabel}, ending ${formatDate(periodEndDate, DateFormats.MonthDay)}`
+    // daysRemainingLabel: `, coming up in ${diffDays} days`
+    // formatDate('2023-12-29'): "29 Dec"
+    // periodEndDate: 29 Dec + 4 days = 2 Jan (29, 30, 31, 1, 2)
+    const label2Days = "Predicted period starting 29 Dec, coming up in 2 days, ending 2 Jan";
+
+    // 30 Dec: 3 days away
+    // periodEndDate: 30 Dec + 4 days = 3 Jan
+    const label3Days = "Predicted period starting 30 Dec, coming up in 3 days, ending 3 Jan";
+
+    // 31 Dec: 4 days away
+    // periodEndDate: 31 Dec + 4 days = 4 Jan
+    // daysRemainingLabel: `, in ${diffDays} days`
+    const label4Days = "Predicted period starting 31 Dec, in 4 days, ending 4 Jan";
+
+    expect(screen.getByLabelText(label2Days)).toBeTruthy();
+    expect(screen.getByLabelText(label3Days)).toBeTruthy();
+    expect(screen.getByLabelText(label4Days)).toBeTruthy();
+  });
+});

--- a/components/ui/IconSymbol.tsx
+++ b/components/ui/IconSymbol.tsx
@@ -31,6 +31,7 @@ const MAPPING = {
   'share': 'share',
   'sparkles': 'auto-awesome',
   'calendar.badge.exclamationmark': 'event-busy',
+  'calendar': 'calendar-today',
 } as Partial<
   Record<
     import('expo-symbols').SymbolViewProps['name'],


### PR DESCRIPTION
💡 What: Added a visual "Upcoming" indicator for periods predicted to start within 2-3 days.
🎯 Why: To give users a helpful heads-up before their period starts, allowing them to prepare. Currently, the app only highlights "Late" periods or "Today/Tomorrow".
📸 Before/After: Before, periods in 2-3 days were shown as plain text "(in X days)". After, they have a blue calendar icon and are labeled "coming up in X days".
♿ Accessibility: Updated `accessibilityLabel` to explicitly mention "coming up in X days" to provide better context for screen reader users.

---
*PR created automatically by Jules for task [9850082846068435855](https://jules.google.com/task/9850082846068435855) started by @dhruvhaldar*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Periods arriving in 2-3 days are now visually distinguished with a new color scheme and calendar icon, making it easier to identify upcoming events at a glance.

* **Tests**
  * Added test coverage for the upcoming periods feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->