### PR TITLE
🎨 Palette: Add relative time context to past predictions

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -52,3 +52,7 @@
 ## 2026-03-02 - Accessible Async Button States
 **Learning:** Conditionally rendering a separate `<ActivityIndicator>` instead of a `<TouchableOpacity>` during an async action (like a file download) causes the focused element to disappear, breaking keyboard/screen reader focus and leading to a jarring user experience.
 **Action:** Embed the `<ActivityIndicator>` directly inside the `<TouchableOpacity>`, set `disabled={isLoading}`, and use `accessibilityState={{ busy: isLoading, disabled: isLoading }}` to provide continuous, semantic feedback without breaking focus.
+
+## 2026-03-03 - Past Date Context in Predictions
+**Learning:** In prediction summaries, calculating the difference between a past date and today without a handler for negative values results in an empty status string, leaving users confused about the timeline of past events.
+**Action:** Always provide explicit relative time labels for both future ("in X days") and past ("X days ago") predictions, ensuring continuity and immediate context for all timeline events.

--- a/components/PredictionSummary.tsx
+++ b/components/PredictionSummary.tsx
@@ -170,6 +170,11 @@ const PredictionSummary = React.memo(function PredictionSummary({
           } else if (diffDays > 5) {
             statusText = ` (in ${diffDays} days)`;
             statusLabel = `, in ${diffDays} days`;
+          } else if (diffDays < 0) {
+            const absDays = Math.abs(diffDays);
+            const daysString = absDays === 1 ? 'day' : 'days';
+            statusText = ` (${absDays} ${daysString} ago)`;
+            statusLabel = `, ${absDays} ${daysString} ago`;
           }
 
           const itemBorderColor = iconName ? statusColor : textColor;


### PR DESCRIPTION
💡 What: Added a relative time indicator ("X days ago") for predicted ovulation dates that have already passed.
🎯 Why: Previously, ovulation dates in the past had an empty `statusText`, making it harder for users to gauge the timeline at a glance.
📸 Before/After: Visualized in `ux_fix2.png`.
♿ Accessibility: Updated the `accessibilityLabel` to correctly announce "X days ago" for screen readers instead of silence.

---
*PR created automatically by Jules for task [12284913920183864462](https://jules.google.com/task/12284913920183864462) started by @dhruvhaldar*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Past prediction events now display relative time labels (e.g., "3 days ago") for better visibility. Previously, past events appeared without status information. This improvement applies consistently to both period and ovulation predictions, ensuring all timeline events provide useful context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->