### PR TITLE
🎨 Palette: Improve input focus styling on web and fix tab layout

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -40,7 +40,7 @@ const AnimatedTabButton = (props: any) => {
       {...rest}
       onPressIn={handlePressIn}
       onPressOut={handlePressOut}
-      style={styles.tabButtonContainer}
+      style={[rest.style, styles.tabButtonContainer]}
       hitSlop={{ top: 20, bottom: 20, left: 20, right: 20 }}
     >
       <Animated.View style={{

--- a/components/NotesInput.tsx
+++ b/components/NotesInput.tsx
@@ -85,6 +85,11 @@ export const NotesInput = memo(forwardRef<NotesInputHandle, NotesInputProps>(({
               color: textColor,
               borderColor: isFocused ? '#E63946' : borderColor,
               borderWidth: isFocused ? 2 : 1,
+              ...Platform.select({
+                web: {
+                  outlineStyle: 'none'
+                }
+              })
             },
           ]}
           multiline


### PR DESCRIPTION
This PR introduces a couple of micro-UX improvements that significantly enhance visual polish and layout consistency:

1. **Native Focus Indicators on Web TextInputs**: Added `outlineStyle: 'none'` via `Platform.select({ web: ... })` to `NotesInput.tsx`. This disables the default browser focus ring (which typically creates a clashing double-border effect) so the custom active state (`borderColor: '#E63946'`) can be rendered cleanly.
2. **Fixed Custom Tab Button Layout**: The `AnimatedTabButton` component in `_layout.tsx` was unintentionally discarding the `style` prop passed down by Expo Router. By properly merging `[rest.style, styles.tabButtonContainer]`, the tab buttons now inherit the correct flex styling, ensuring they are positioned and spaced evenly across the bottom tab bar.

These changes are < 50 lines, avoid regressions, and improve the consistency of the application's UI on both web and native targets.

---
*PR created automatically by Jules for task [6758360327036029247](https://jules.google.com/task/6758360327036029247) started by @dhruvhaldar*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved tab button styling composition to better support custom style overrides.
  * Removed outline styling on notes input field for web platform for a cleaner appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->