### PR TITLE
🎨 Palette: Add UX hover/focus states to StepperInput

### DIFF
--- a/components/StepperInput.tsx
+++ b/components/StepperInput.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, memo, useRef, useEffect, useState } from 'react';
 import {
   StyleSheet,
   TextInput,
-  TouchableOpacity,
+  Pressable,
   View,
   Platform,
   ViewStyle,
@@ -109,18 +109,26 @@ export const StepperInput = memo(function StepperInput({
 
   return (
     <View style={[styles.container, style]}>
-      <TouchableOpacity
+      <Pressable
         onPress={performDecrement}
         onLongPress={startRapidDecrement}
         onPressOut={stopTimer}
-        style={[styles.button, { borderColor, opacity: isAtMin ? 0.5 : 1 }]}
+        style={({ pressed, hovered, focused }: any) => [
+          styles.button,
+          {
+            borderColor,
+            opacity: isAtMin ? 0.5 : pressed ? 0.7 : 1,
+            backgroundColor: hovered || focused ? 'rgba(0,0,0,0.05)' : 'transparent',
+            ...(Platform.OS === 'web' && focused && { outlineStyle: 'solid', outlineWidth: 2, outlineColor: '#E63946' })
+          }
+        ]}
         accessibilityRole="button"
         accessibilityLabel={`Decrease ${label}`}
         disabled={isAtMin}
         delayLongPress={300}
       >
         <IconSymbol name="minus" size={20} color={textColor} />
-      </TouchableOpacity>
+      </Pressable>
 
       <TextInput
         style={[
@@ -149,18 +157,26 @@ export const StepperInput = memo(function StepperInput({
         maxLength={3}
       />
 
-      <TouchableOpacity
+      <Pressable
         onPress={performIncrement}
         onLongPress={startRapidIncrement}
         onPressOut={stopTimer}
-        style={[styles.button, { borderColor, opacity: isAtMax ? 0.5 : 1 }]}
+        style={({ pressed, hovered, focused }: any) => [
+          styles.button,
+          {
+            borderColor,
+            opacity: isAtMax ? 0.5 : pressed ? 0.7 : 1,
+            backgroundColor: hovered || focused ? 'rgba(0,0,0,0.05)' : 'transparent',
+            ...(Platform.OS === 'web' && focused && { outlineStyle: 'solid', outlineWidth: 2, outlineColor: '#E63946' })
+          }
+        ]}
         accessibilityRole="button"
         accessibilityLabel={`Increase ${label}`}
         disabled={isAtMax}
         delayLongPress={300}
       >
         <IconSymbol name="plus" size={20} color={textColor} />
-      </TouchableOpacity>
+      </Pressable>
     </View>
   );
 });


### PR DESCRIPTION
🎨 Palette: [UX improvement] Add Pressable Hover and Focus States to StepperInput

💡 **What**: Replaced `TouchableOpacity` with `Pressable` for the decrement and increment buttons within the `StepperInput` component to support explicit `hovered` and `focused` styles.
🎯 **Why**: When navigating the application using a keyboard, the `+` and `-` buttons lacked visual feedback indicating they were focused or hovered, making the interaction cost higher for users. This change improves accessibility significantly on web platforms.
♿ **Accessibility**: Enhanced keyboard navigation by adding clear focus rings to actionable buttons, ensuring users know which element is currently targeted.

---
*PR created automatically by Jules for task [6247617597069233081](https://jules.google.com/task/6247617597069233081) started by @dhruvhaldar*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Enhanced stepper input buttons with improved visual feedback during interactions.
  * Added platform-aware styling with better visual indication for pressed, hovered, and focused states.
  * Improved visual clarity for disabled states across all devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->