### PR TITLE
🎨 Palette: Improve focus and hover UX states on web buttons

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -369,7 +369,8 @@ export default function HomeScreen() {
             Platform.OS === 'web' && focused && {
               outlineStyle: 'solid',
               outlineWidth: 2,
-              outlineColor: '#E63946'
+              outlineColor: '#E63946',
+              outlineOffset: 2
             }
           ]}
           accessibilityLabel={`Select last period start date. Current: ${formattedLastPeriod}`}

--- a/components/StepperInput.tsx
+++ b/components/StepperInput.tsx
@@ -114,7 +114,7 @@ export const StepperInput = memo(function StepperInput({
             borderColor,
             opacity: isAtMin ? 0.5 : pressed ? 0.7 : 1,
             backgroundColor: hovered || focused ? 'rgba(0,0,0,0.05)' : 'transparent',
-            ...(Platform.OS === 'web' && focused && { outlineStyle: 'solid', outlineWidth: 2, outlineColor: '#E63946' })
+            ...(Platform.OS === 'web' && focused && { outlineStyle: 'solid', outlineWidth: 2, outlineColor: '#E63946', outlineOffset: 2 })
           }
         ]}
         accessibilityRole="button"
@@ -162,7 +162,7 @@ export const StepperInput = memo(function StepperInput({
             borderColor,
             opacity: isAtMax ? 0.5 : pressed ? 0.7 : 1,
             backgroundColor: hovered || focused ? 'rgba(0,0,0,0.05)' : 'transparent',
-            ...(Platform.OS === 'web' && focused && { outlineStyle: 'solid', outlineWidth: 2, outlineColor: '#E63946' })
+            ...(Platform.OS === 'web' && focused && { outlineStyle: 'solid', outlineWidth: 2, outlineColor: '#E63946', outlineOffset: 2 })
           }
         ]}
         accessibilityRole="button"

--- a/components/ui/EmptyState.tsx
+++ b/components/ui/EmptyState.tsx
@@ -115,6 +115,7 @@ export function EmptyState({ title, message, icon, actionLabel, onAction, style 
             style={({ pressed, hovered, focused }: { pressed: boolean; hovered?: boolean; focused?: boolean }) => [
               styles.button,
               pressed && { opacity: 0.7 },
+              (hovered || focused) && { backgroundColor: '#c5303c' },
               Platform.OS === 'web' && focused && {
                 outlineStyle: 'solid',
                 outlineWidth: 2,


### PR DESCRIPTION
💡 What: Added `outlineOffset: 2` to several buttons with borders (`StepperInput` increment/decrement buttons, `Date` button) and added a missing hover background color to the `EmptyState` CTA button.

🎯 Why: To ensure keyboard focus rings are visible when the component already has a border (they tend to blend in otherwise), and to provide visual feedback for mouse users hovering over the EmptyState button.

📸 Before/After: See Playwright screenshots verifying the offset focus ring on Stepper/Date buttons, and the new hover state on the EmptyState CTA.

♿ Accessibility: Greatly improves keyboard navigation visibility on the web target by un-merging the focus ring from the component's existing border stroke.

---
*PR created automatically by Jules for task [2379626549401560189](https://jules.google.com/task/2379626549401560189) started by @dhruvhaldar*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved focus outline styling for form inputs and buttons on web
  * Enhanced visual feedback for interactive elements during focus and hover states

<!-- end of auto-generated comment: release notes by coderabbit.ai -->