### PR TITLE
🎨 Palette: Improve Tab Bar Web Accessibility with Focus Rings

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,6 +1,6 @@
 import { Tabs } from 'expo-router';
 import React, { useRef } from 'react';
-import { StyleSheet, TouchableOpacity, ViewStyle, Animated, View } from 'react-native';
+import { StyleSheet, Pressable, Platform, ViewStyle, Animated, View } from 'react-native';
 
 import { IconSymbol } from '@/components/ui/IconSymbol';
 import TabBarBackground from '@/components/ui/TabBarBackground';
@@ -36,11 +36,23 @@ const AnimatedTabButton = (props: any) => {
   };
 
   return (
-    <TouchableOpacity
+    <Pressable
       {...rest}
       onPressIn={handlePressIn}
       onPressOut={handlePressOut}
-      style={[rest.style, styles.tabButtonContainer]}
+      style={({ pressed, hovered, focused }: any) => [
+        rest.style,
+        styles.tabButtonContainer,
+        { opacity: pressed ? 0.7 : 1 },
+        Platform.select({
+          web: {
+            outlineStyle: focused ? 'solid' : 'none',
+            outlineWidth: 2,
+            outlineColor: '#E63946',
+            outlineOffset: 2,
+          } as any,
+        }),
+      ]}
       hitSlop={{ top: 20, bottom: 20, left: 20, right: 20 }}
     >
       <Animated.View style={{
@@ -50,7 +62,7 @@ const AnimatedTabButton = (props: any) => {
       }}>
         {children}
       </Animated.View>
-    </TouchableOpacity>
+    </Pressable>
   );
 };
 


### PR DESCRIPTION
💡 What: Replaced the legacy `TouchableOpacity` in the bottom tab bar (`AnimatedTabButton`) with a more robust `Pressable` component. Configured web-specific styles to render an explicit red focus ring (`outlineStyle: 'solid'`, `outlineWidth: 2`, `outlineColor: '#E63946'`) during keyboard navigation. 

🎯 Why: Users navigating the web version via keyboard could not see which tab was focused because `TouchableOpacity` lacks robust cross-platform focus and hover handling. This ensures a predictable, compliant, and visible focus state without altering native iOS/Android behaviors. 

📸 Before/After: Verified with Playwright screenshots. The web focus ring now correctly outlines the selected tab button when focused via the `Tab` key.

♿ Accessibility: Directly improves WCAG focus visibility success criteria on the primary navigation.

---
*PR created automatically by Jules for task [14498933933431858230](https://jules.google.com/task/14498933933431858230) started by @dhruvhaldar*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved tab bar button interaction feedback with enhanced focus styling on web.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->