### PR TITLE
🎨 Palette: Add accessibility states to StepperInput buttons

### DIFF
--- a/components/StepperInput.tsx
+++ b/components/StepperInput.tsx
@@ -119,6 +119,7 @@ export const StepperInput = memo(function StepperInput({
         ]}
         accessibilityRole="button"
         accessibilityLabel={`Decrease ${label}`}
+        accessibilityState={{ disabled: isAtMin }}
         disabled={isAtMin}
         delayLongPress={300}
       >
@@ -167,6 +168,7 @@ export const StepperInput = memo(function StepperInput({
         ]}
         accessibilityRole="button"
         accessibilityLabel={`Increase ${label}`}
+        accessibilityState={{ disabled: isAtMax }}
         disabled={isAtMax}
         delayLongPress={300}
       >


### PR DESCRIPTION
💡 What: Added `accessibilityState={{ disabled: ... }}` to the increment and decrement buttons in the `StepperInput` component.
🎯 Why: While the buttons were visually and functionally disabled (using the `disabled` prop and `opacity` styles) when reaching their limits, screen readers (like VoiceOver or TalkBack) require explicit `accessibilityState` metadata to announce the disabled state properly to visually impaired users.
📸 Before/After: Visuals remain identical (no regression). On web, this translates to explicitly adding the `aria-disabled="true"` attribute when the buttons reach their min/max values.
♿ Accessibility: Screen reader users will now be correctly informed when they can no longer increment or decrement a value in the `StepperInput` (e.g., when setting cycle length or period duration).

---
*PR created automatically by Jules for task [4151342330668583654](https://jules.google.com/task/4151342330668583654) started by @dhruvhaldar*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Enhanced accessibility state communication for stepper controls, ensuring assistive technologies properly recognize when increment and decrement buttons are disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->