### PR TITLE
🎨 Palette: Announce character limit to screen readers

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,7 @@
 ## 2024-03-24 - Improve screen reader support for ChatInput character count
 **Learning:** The character limit indicator in the `ChatInput` component was purely visual. Providing this context (e.g., '0 characters used out of 200') to screen readers using `accessibilityLabel` ensures an equitable experience and aligns with the pattern used in `NotesInput`.
 **Action:** Add `accessibilityLabel` to text components acting as character counters to make their purpose and status explicit to assistive technology.
+
+## 2024-05-18 - Input Limit Accessibility
+**Learning:** Custom visual/haptic feedback for input limits (like "shake" animations) leaves screen reader users unaware of why their input is clamped when native `maxLength` is removed to facilitate the custom feedback.
+**Action:** Always pair custom programmatic input clamping with `AccessibilityInfo.announceForAccessibility` to ensure equitable, immediate feedback for screen reader users.

--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -1,5 +1,5 @@
 import React, { useState, forwardRef, useImperativeHandle, useRef, useCallback } from 'react';
-import { TextInput, View, Pressable, ActivityIndicator, StyleSheet, Platform } from 'react-native';
+import { TextInput, View, Pressable, ActivityIndicator, StyleSheet, Platform, AccessibilityInfo } from 'react-native';
 import Animated, { useSharedValue, useAnimatedStyle, withSequence, withTiming } from 'react-native-reanimated';
 import * as Haptics from 'expo-haptics';
 import { ThemedText } from './ThemedText';
@@ -51,6 +51,9 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(({ onSubmit
 
   const handleTextChange = (newText: string) => {
     if (newText.length > MAX_INPUT_LENGTH) {
+      // Announce to screen readers since native maxLength is removed
+      AccessibilityInfo.announceForAccessibility(`Maximum character limit of ${MAX_INPUT_LENGTH} reached`);
+
       // Trigger shake animation
       shake.value = withSequence(
         withTiming(-10, { duration: 50 }),

--- a/components/NotesInput.tsx
+++ b/components/NotesInput.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useImperativeHandle, forwardRef, memo, useRef } from 'react';
-import { TextInput, StyleSheet, Pressable, View, Platform } from 'react-native';
+import { TextInput, StyleSheet, Pressable, View, Platform, AccessibilityInfo } from 'react-native';
 import Animated, { useSharedValue, useAnimatedStyle, withSequence, withTiming } from 'react-native-reanimated';
 import * as Haptics from 'expo-haptics';
 import { ThemedView } from '@/components/ThemedView';
@@ -45,6 +45,9 @@ export const NotesInput = memo(forwardRef<NotesInputHandle, NotesInputProps>(({
 
   const handleNotesChange = useCallback((text: string) => {
     if (text.length > MAX_NOTES_LENGTH) {
+        // Announce to screen readers since native maxLength is removed
+        AccessibilityInfo.announceForAccessibility(`Maximum character limit of ${MAX_NOTES_LENGTH} reached`);
+
         // Trigger shake animation
         shake.value = withSequence(
           withTiming(-10, { duration: 50 }),


### PR DESCRIPTION
🎨 Palette: Announce character limit to screen readers

**💡 What**:
Added `AccessibilityInfo.announceForAccessibility` to both `ChatInput` and `NotesInput` when their respective programmatic character limits are reached.

**🎯 Why**:
Because we removed the native `maxLength` prop to allow for custom visual (shake) and haptic feedback when users hit the character limit, we inadvertently removed the native screen reader support that announces when an input can no longer accept text. Adding an explicit accessibility announcement ensures screen reader users aren't left wondering why their input is being clamped.

**♿ Accessibility**:
Restores equitable feedback for screen reader users when programmatic input limits are hit.

---
*PR created automatically by Jules for task [6655841452032243208](https://jules.google.com/task/6655841452032243208) started by @dhruvhaldar*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * **Screen Reader Support for Input Limits**: When users reach the maximum character limit in chat input and notes fields, screen readers will automatically announce this restriction. This provides clear audio feedback, significantly improving accessibility and usability for anyone relying on screen readers or other assistive technologies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->