### PR TITLE
🎨 Palette: Improve accessibility of header images

### DIFF
--- a/app/(tabs)/chatbot.tsx
+++ b/app/(tabs)/chatbot.tsx
@@ -92,6 +92,8 @@ export default function MenstruationScreen() {
       source={require('@/assets/images/history2.png')}
       style={styles.reactLogo}
       resizeMode="contain"
+      accessible={false}
+      importantForAccessibility="no"
     />
   ), []);
 

--- a/app/(tabs)/history.tsx
+++ b/app/(tabs)/history.tsx
@@ -134,6 +134,8 @@ export default function TabTwoScreen() {
       source={require('@/assets/images/history2.png')}
       style={styles.reactLogo}
       resizeMode="contain"
+      accessible={false}
+      importantForAccessibility="no"
     />
   ), []);
 

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -62,6 +62,9 @@ export default function HomeScreen() {
       source={require('@/assets/images/LunaBloom_adaptive.png')}
       style={styles.reactLogo}
       resizeMode="contain"
+      accessible={true}
+      accessibilityRole="image"
+      accessibilityLabel="LunaBloom logo"
     />
   ), []);
 

--- a/app/(tabs)/insights.tsx
+++ b/app/(tabs)/insights.tsx
@@ -39,6 +39,8 @@ export default function InsightsScreen() {
       source={require('@/assets/images/history2.png')}
       style={styles.reactLogo}
       resizeMode="contain"
+      accessible={false}
+      importantForAccessibility="no"
     />
   ), []);
 

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -28,6 +28,8 @@ export default function SettingsScreen() {
             source={require('@/assets/images/history2.png')}
             style={styles.reactLogo}
             resizeMode="contain"
+            accessible={false}
+            importantForAccessibility="no"
         />
     ), []);
     


### PR DESCRIPTION
🎨 Palette: Improved accessibility of header images. Added a descriptive label to the main LunaBloom logo, and explicitly hid decorative header illustrations from screen readers to reduce noise.

---
*PR created automatically by Jules for task [3588413512182238389](https://jules.google.com/task/3588413512182238389) started by @dhruvhaldar*