### PR TITLE
🎨 Palette: Hide decorative EmptyState icon from screen readers

### DIFF
--- a/components/__tests__/EmptyState-test.tsx
+++ b/components/__tests__/EmptyState-test.tsx
@@ -60,8 +60,8 @@ describe('EmptyState', () => {
     expect(onAction).toHaveBeenCalled();
   });
 
-  it('renders icon with accessibility props', () => {
-    const { getByLabelText } = render(
+  it('renders icon and hides it from screen readers', () => {
+    const { getByTestId } = render(
       <EmptyState
         title="No Insights"
         message="Log more data"
@@ -69,9 +69,9 @@ describe('EmptyState', () => {
       />
     );
 
-    // Query by label text which I added
-    const iconContainer = getByLabelText('No Insights illustration');
+    const iconContainer = getByTestId('empty-state-icon-container');
     expect(iconContainer).toBeTruthy();
-    expect(iconContainer.props.accessibilityRole).toBe('image');
+    expect(iconContainer.props.accessible).toBe(false);
+    expect(iconContainer.props.importantForAccessibility).toBe('no');
   });
 });

--- a/components/ui/EmptyState.tsx
+++ b/components/ui/EmptyState.tsx
@@ -92,8 +92,9 @@ export function EmptyState({ title, message, icon, actionLabel, onAction, style 
               { translateY: floatAnim }
             ]
           }}
-          accessibilityRole="image"
-          accessibilityLabel={`${title} illustration`}
+          accessible={false}
+          importantForAccessibility="no"
+          testID="empty-state-icon-container"
         >
           <IconSymbol
             name={icon}


### PR DESCRIPTION
🎨 Palette: Hide decorative EmptyState icon from screen readers

💡 What: Updated the `EmptyState` component to explicitly hide the animated illustration from screen readers. 
🎯 Why: Empty state icons are typically visual embellishments (decorative). Previously, the screen reader would announce "[Title] illustration" followed immediately by the text "[Title]". Hiding the icon removes this redundant announcement, making the experience cleaner and less frustrating for users relying on assistive technologies.
♿ Accessibility: Set `accessible={false}` and `importantForAccessibility="no"` on the illustration container. Also updated corresponding Jest tests to verify these props using `testID`.

---
*PR created automatically by Jules for task [8559106054873887536](https://jules.google.com/task/8559106054873887536) started by @dhruvhaldar*