### PR TITLE
🎨 Palette: Add accessibilityHint to EmptyState actions

### DIFF
--- a/app/(tabs)/history.tsx
+++ b/app/(tabs)/history.tsx
@@ -101,6 +101,7 @@ export default function TabTwoScreen() {
         message="Track your first period to start seeing your history here."
         icon="clock.fill"
         actionLabel="Log Period"
+        actionHint="Navigates to the home screen to log a new period"
         onAction={handleEmptyAction}
       />
     )

--- a/app/(tabs)/insights.tsx
+++ b/app/(tabs)/insights.tsx
@@ -220,6 +220,7 @@ export default function InsightsScreen() {
                   message="Log more periods to unlock trends and insights."
                   icon="chart.bar.fill"
                   actionLabel="Log Now"
+                  actionHint="Navigates to the home screen to log a new period"
                   onAction={() => router.push('/')}
                   style={{ marginTop: 10, padding: 20 }}
                 />

--- a/components/__tests__/EmptyState-test.tsx
+++ b/components/__tests__/EmptyState-test.tsx
@@ -48,6 +48,7 @@ describe('EmptyState', () => {
         title="No Data"
         message="Message"
         actionLabel="Retry"
+        actionHint="Tap to retry loading data"
         onAction={onAction}
       />
     );
@@ -55,6 +56,7 @@ describe('EmptyState', () => {
     // Check button role
     const button = getByRole('button', { name: 'Retry' });
     expect(button).toBeTruthy();
+    expect(button.props.accessibilityHint).toBe('Tap to retry loading data');
 
     fireEvent.press(button);
     expect(onAction).toHaveBeenCalled();

--- a/components/ui/EmptyState.tsx
+++ b/components/ui/EmptyState.tsx
@@ -10,11 +10,12 @@ interface EmptyStateProps {
   message: string;
   icon?: IconSymbolName;
   actionLabel?: string;
+  actionHint?: string;
   onAction?: () => void;
   style?: ViewStyle;
 }
 
-export function EmptyState({ title, message, icon, actionLabel, onAction, style }: EmptyStateProps) {
+export function EmptyState({ title, message, icon, actionLabel, actionHint, onAction, style }: EmptyStateProps) {
   const colorScheme = useColorScheme();
   const iconColor = colorScheme === 'dark' ? '#457B9D' : '#A8DADC'; // Muted brand color
   const textColor = colorScheme === 'dark' ? '#F1FAEE' : '#1D3557';
@@ -127,6 +128,7 @@ export function EmptyState({ title, message, icon, actionLabel, onAction, style 
             onPress={onAction}
             accessibilityRole="button"
             accessibilityLabel={actionLabel}
+            accessibilityHint={actionHint}
           >
             <ThemedText style={styles.buttonText}>{actionLabel}</ThemedText>
           </Pressable>


### PR DESCRIPTION
## 🎨 Palette: Accessibility Enhancement for EmptyState

**💡 What:**
Added a new `actionHint` prop to the `EmptyState` component and passed it down as the `accessibilityHint` on the action button. Applied this new prop to the empty state screens on the History and Insights tabs.

**🎯 Why:**
When a screen reader encounters the "Log Period" or "Log Now" buttons in an empty state, it reads the label, but it might not be immediately clear *what* logging a period entails (e.g., does it open a modal, or does it navigate elsewhere?). By adding an `accessibilityHint` like "Navigates to the home screen to log a new period", we provide crucial context that reduces ambiguity and improves the experience for users relying on assistive technology.

**♿ Accessibility:**
- Added `accessibilityHint` support to the reusable `EmptyState` component.
- Improved context for screen reader users on the History and Insights empty screens.
- Re-ran tests, which verified the new props and updated an unrelated formatting inconsistency in an existing snapshot.

---
*PR created automatically by Jules for task [10123389713181952516](https://jules.google.com/task/10123389713181952516) started by @dhruvhaldar*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added action hints to buttons displayed on empty state screens in History and Insights sections, providing contextual information about the impact of available actions.

* **Tests**
  * Enhanced test suite with new cases verifying that action hints are properly rendered and accessible to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->