### PR TITLE
🎨 Palette: Connect form labels to inputs via aria-labelledby on Period Tracker

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -361,7 +361,7 @@ export default function HomeScreen() {
 
       {/* Last Period Date */}
       <ThemedView style={styles.inputGroup}>
-        <ThemedText style={{ color: textColor }}>Last Period Start</ThemedText>
+        <ThemedText nativeID="last-period-label" style={{ color: textColor }}>Last Period Start</ThemedText>
         <Pressable
           onPress={showDatepicker}
           style={({ pressed, hovered, focused }: any) => [
@@ -379,6 +379,8 @@ export default function HomeScreen() {
           accessibilityLabel={`Select last period start date. Current: ${formattedLastPeriod}`}
           accessibilityHint="Opens a date picker to select when your last period started"
           accessibilityRole="button"
+          aria-labelledby="last-period-label"
+          aria-haspopup="dialog"
         >
           <IconSymbol name="calendar" size={16} color={textColor} />
           <ThemedText style={[styles.dateText, { color: textColor }]}>
@@ -399,7 +401,7 @@ export default function HomeScreen() {
       {/* Cycle Length */}
       <View>
         <ThemedView style={styles.inputGroup}>
-          <ThemedText style={{ color: textColor }}>Cycle Length (days)</ThemedText>
+          <ThemedText nativeID="cycle-length-label" style={{ color: textColor }}>Cycle Length (days)</ThemedText>
           <StepperInput
             value={cycleLength}
             onChangeText={handleCycleLengthChange}
@@ -407,6 +409,7 @@ export default function HomeScreen() {
             min={15}
             max={120}
             label="Cycle length in days"
+            aria-labelledby="cycle-length-label"
           />
         </ThemedView>
         {cycleWarning && (
@@ -422,7 +425,7 @@ export default function HomeScreen() {
       {/* Period Duration */}
       <View>
         <ThemedView style={styles.inputGroup}>
-          <ThemedText style={{ color: textColor }}>Period Duration (days)</ThemedText>
+          <ThemedText nativeID="period-duration-label" style={{ color: textColor }}>Period Duration (days)</ThemedText>
           <StepperInput
             value={periodDuration}
             onChangeText={handlePeriodDurationChange}
@@ -430,6 +433,7 @@ export default function HomeScreen() {
             min={1}
             max={14}
             label="Period duration in days"
+            aria-labelledby="period-duration-label"
           />
         </ThemedView>
         {periodWarning && (

--- a/components/StepperInput.tsx
+++ b/components/StepperInput.tsx
@@ -20,6 +20,7 @@ interface StepperInputProps {
   max?: number;
   label: string;
   style?: StyleProp<ViewStyle>;
+  "aria-labelledby"?: string;
 }
 
 // Optimization: Use memo to prevent re-renders when parent state changes (e.g. typing notes)
@@ -32,6 +33,7 @@ export const StepperInput = memo(function StepperInput({
   max = 100,
   label,
   style,
+  "aria-labelledby": ariaLabelledBy,
 }: StepperInputProps) {
   const textColor = useThemeColor({}, 'text');
   const borderColor = textColor;
@@ -148,6 +150,7 @@ export const StepperInput = memo(function StepperInput({
         accessibilityLabel={label}
         accessibilityRole="spinbutton"
         accessibilityValue={{ min, max, now: numericValue || 0 }}
+        aria-labelledby={ariaLabelledBy}
         selectTextOnFocus={true}
         returnKeyType="done"
         maxLength={3}


### PR DESCRIPTION
💡 What: Added `aria-labelledby` and `nativeID` connections between visual text labels and their respective input controls (`StepperInput` and `Pressable` Date Pickers) on the Period Tracker screen.

🎯 Why: Previously, screen reader users navigating to these inputs would only hear the `accessibilityLabel` or `accessibilityRole`, which can sometimes fail to fully communicate the visual context of the label beside it. Programmatically linking the label via `aria-labelledby` ensures robust screen reader support.

♿ Accessibility: Ensures that screen reader users clearly understand the purpose of the inputs for Cycle Length, Period Duration, and Last Period Start date.

---
*PR created automatically by Jules for task [5707843555773201959](https://jules.google.com/task/5707843555773201959) started by @dhruvhaldar*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Enhanced label associations for form controls to improve screen reader and assistive technology support.
  * Added clearer indicators for interactive elements that open dialogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->