### PR TITLE
🎨 Palette: Add accessibilityHint to About button

### DIFF
--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -460,6 +460,7 @@ export default function SettingsScreen() {
                         ]}
                         accessibilityRole="button"
                         accessibilityLabel="About the app"
+                        accessibilityHint="Shows information about the app"
                     >
                          <IconSymbol name="info.circle" size={20} color="#457B9D" style={{ marginRight: 6 }} />
                         <ThemedText style={styles.aboutAppText}>About</ThemedText>


### PR DESCRIPTION
Added an `accessibilityHint` to the "About" button in the Settings screen to provide more context to screen reader users, following the pattern of other interactive elements in the application.

---
*PR created automatically by Jules for task [14719517898272252766](https://jules.google.com/task/14719517898272252766) started by @dhruvhaldar*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved screen reader support for the About the app button in Settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->