### PR TITLE
🎨 Palette: Explicit Accessibility Linking in NotesInput

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -14,3 +14,10 @@
 **Learning:** React Native Web mapping for `TouchableOpacity` doesn't always handle keyboard navigation focus effectively on the web, often failing to show custom focus rings or missing subtle hover states on icon buttons.
 **Action:** Replace `TouchableOpacity` with `Pressable` for interactive elements (especially icon buttons) when web support is needed. Utilize the `({ pressed, hovered, focused })` state parameters to add explicit background color changes on hover/focus, and `Platform.select({ web: { outlineStyle: 'solid' } })` to ensure keyboard focus is always visible.
 \n## 2025-05-24 - Enhancing Focus Rings on Bordered Components\n**Learning:** When adding focus rings (`outlineColor`) to components that already have borders, the focus ring can blend into the border and become difficult to see for keyboard users.\n**Action:** Use `outlineOffset: 2` along with a distinct `outlineColor` (like the primary brand color) to ensure the focus ring appears clearly outside the component's border, significantly improving accessibility for keyboard navigation.
+## 2024-05-24 - Explicit ID association for form inputs
+**Learning:** Screen readers may not consistently associate visual labels (like a standalone  component) with interactive inputs (like ) unless explicitly linked.
+**Action:** Use  on the visual label and the matching  attribute on the  to guarantee a strong programmatic connection for screen readers.
+
+## 2024-05-24 - Explicit ID association for form inputs
+**Learning:** Screen readers may not consistently associate visual labels (like a standalone `ThemedText` component) with interactive inputs (like `TextInput`) unless explicitly linked.
+**Action:** Use `nativeID` on the visual label and the matching `aria-labelledby` attribute on the `TextInput` to guarantee a strong programmatic connection for screen readers.

--- a/components/NotesInput.tsx
+++ b/components/NotesInput.tsx
@@ -75,13 +75,14 @@ export const NotesInput = memo(forwardRef<NotesInputHandle, NotesInputProps>(({
 
   return (
     <ThemedView style={styles.section}>
-      <ThemedText type="subtitle" style={{ color: headingColor, marginBottom: 10 }}>
+      <ThemedText nativeID="notes-label" type="subtitle" style={{ color: headingColor, marginBottom: 10 }}>
         Notes 🗒️
       </ThemedText>
       <View style={styles.inputContainer}>
         <Animated.View style={shakeStyle}>
           <TextInput
           ref={inputRef}
+          aria-labelledby="notes-label"
           style={[
             styles.notesInput,
             {


### PR DESCRIPTION
🎨 Palette: Explicit Accessibility Linking in NotesInput

💡 What: Added `nativeID` to the "Notes" label text component and `aria-labelledby` to the corresponding `TextInput`.
🎯 Why: Screen readers may not inherently associate a loose text component with a `TextInput`. Explicitly linking the two guarantees that when users focus the input, the appropriate label is announced.
📸 Before/After: No visual change.
♿ Accessibility: Improved programmatic form label association for screen reader users on both mobile and web.

---
*PR created automatically by Jules for task [18182741312379275095](https://jules.google.com/task/18182741312379275095) started by @dhruvhaldar*