### PR TITLE
chore: add accessibilityHint to delete button in HistoryItem

### DIFF
--- a/components/HistoryItem.tsx
+++ b/components/HistoryItem.tsx
@@ -114,6 +114,7 @@ const HistoryItem = React.memo(function HistoryItem({ item, onDelete, textColor,
           ]}
           onPress={() => onDelete(item.date)}
           accessibilityLabel={`Delete entry from ${logDate}`}
+          accessibilityHint="Permanently deletes this entry from your history"
           accessibilityRole="button"
         >
           <IconSymbol name="trash.fill" size={24} color={deleteIconColor} />


### PR DESCRIPTION
🎨 Palette: Add accessibilityHint to icon-only delete button

💡 **What:** Added an `accessibilityHint` ("Permanently deletes this entry from your history") to the delete button in `components/HistoryItem.tsx`.
🎯 **Why:** Icon-only buttons that perform destructive actions need additional context for screen reader users so they understand the consequence before activating the control.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Screen reader users now hear both what the button is ("Delete entry from [date]") and what will happen if they click it ("Permanently deletes this entry from your history").

---
*PR created automatically by Jules for task [12649016664750392330](https://jules.google.com/task/12649016664750392330) started by @dhruvhaldar*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced accessibility for deleting history entries with clearer guidance for assistive technology users regarding the permanent nature of the deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->