### PR TITLE
🎨 Palette: Add tooltips and hints to icon-only clear buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -15,3 +15,4 @@
 ## 2024-05-18 - Async Loading States
 **Learning:** Transient loading states for async actions like `navigator.share` can appear briefly or not at all depending on platform capabilities (like mocked APIs in Expo Web), leading to poor or missing user feedback. The "Export" button was doing this, and the "Share" button also suffered from it.
 **Action:** Always wrap async actions on interactive elements with explicit loading state variables (e.g., `isSharing`), render visual feedback (like `ActivityIndicator` and updated label), and explicitly update `accessibilityState={{ busy: true, disabled: true }}` to notify screen readers.
+## 2024-05-18 - Tooltips on Icon Buttons\n**Learning:** Icon-only buttons using `Pressable` on React Native Web can lack visual context on hover for mouse users. \n**Action:** Add tooltips by conditionally spreading the `title` HTML attribute using `{...(Platform.OS === 'web' ? { title: 'Action text' } : {})}`.

--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -127,8 +127,10 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(({ onSubmit
                 ]}
                 onPress={handleClear}
                 accessibilityLabel="Clear question"
+                accessibilityHint="Clears the current question"
                 accessibilityRole="button"
                 hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+                {...(Platform.OS === 'web' ? { title: 'Clear question' } : {})}
               >
                 <IconSymbol name="xmark.circle.fill" size={20} color={placeholderTextColor} />
               </Pressable>

--- a/components/NotesInput.tsx
+++ b/components/NotesInput.tsx
@@ -122,8 +122,10 @@ export const NotesInput = memo(forwardRef<NotesInputHandle, NotesInputProps>(({
               ]}
               onPress={handleClear}
               accessibilityLabel="Clear notes"
+              accessibilityHint="Clears the current notes"
               accessibilityRole="button"
               hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+              {...(Platform.OS === 'web' ? { title: 'Clear notes' } : {})}
             >
               <IconSymbol name="xmark.circle.fill" size={20} color={placeholderTextColor} />
             </Pressable>


### PR DESCRIPTION
💡 What: The clear ("x") icon buttons in `NotesInput` and `ChatInput` were updated to include `accessibilityHint`s and native web tooltips via the `title` attribute.
🎯 Why: Icon-only buttons performing destructive actions need extra context. The `accessibilityHint` helps screen reader users understand the outcome of the action ("Clears the current text"), while the tooltip (`title`) aids mouse users on the web who hover over the icon.
📸 Before/After: Visual change on the web (tooltips appear on hover over the "x" button in inputs).
♿ Accessibility: Better context for screen readers and mouse users.

---
*PR created automatically by Jules for task [17117712234604801552](https://jules.google.com/task/17117712234604801552) started by @dhruvhaldar*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility of clear buttons across the application with larger touch targets, enhanced screen reader support, and clearer labeling for better usability.

* **Documentation**
  * Added accessibility best practices for implementing icon-only buttons in React Native Web.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->