### PR TITLE
🎨 Palette: Add outlineOffset to improve focus ring visibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -19,3 +19,7 @@
 ## 2026-06-13 - Explicit aria-checked on Web Switch
 **Learning:** React Native Web's translation of `accessibilityState={{ checked: value }}` may not consistently expose the required `aria-checked` property on custom toggle elements across all versions/browsers.
 **Action:** When building custom web-compatible Switch or Toggle components in React Native using `Pressable`, explicitly pass `{...(Platform.OS === 'web' ? { 'aria-checked': value } : {})}` to ensure robust screen reader compatibility.
+
+## 2024-05-25 - Verify Conditional UI Elements in Verification Scripts
+**Learning:** When using Playwright to verify a UI element that only appears conditionally (e.g., a "Clear" button that appears only when an input is populated), the script must explicitly perform the prerequisite actions to trigger visibility before targeting the element.
+**Action:** Always mock or input prerequisite state (like using `fill` on an input via `page.get_by_placeholder`) in verification scripts before interacting with conditionally rendered UI components.

--- a/components/HistoryItem.tsx
+++ b/components/HistoryItem.tsx
@@ -109,7 +109,8 @@ const HistoryItem = React.memo(function HistoryItem({ item, onDelete, textColor,
             Platform.OS === 'web' && focused && {
               outlineStyle: 'solid',
               outlineWidth: 2,
-              outlineColor: deleteIconColor
+              outlineColor: deleteIconColor,
+              outlineOffset: 2
             }
           ]}
           onPress={() => onDelete(item.date)}

--- a/components/NotesInput.tsx
+++ b/components/NotesInput.tsx
@@ -117,7 +117,8 @@ export const NotesInput = memo(forwardRef<NotesInputHandle, NotesInputProps>(({
                 Platform.OS === 'web' && focused && {
                   outlineStyle: 'solid',
                   outlineWidth: 2,
-                  outlineColor: placeholderTextColor
+                  outlineColor: placeholderTextColor,
+                  outlineOffset: 2
                 }
               ]}
               onPress={handleClear}


### PR DESCRIPTION
💡 **What:** Added `outlineOffset: 2` to the focus state styles of the clear button in `NotesInput.tsx` and the delete button in `HistoryItem.tsx`.

🎯 **Why:** To improve accessibility for keyboard users on the web. When components already have a border, applying a solid focus ring without an offset can cause the ring to blend into the existing border, making the focus state difficult to discern. Adding an offset ensures the ring is clearly separated from the component.

♿ **Accessibility:** Enhances keyboard navigation visibility by making focus rings distinctly visible outside the boundaries of bordered interactive elements.

---
*PR created automatically by Jules for task [17386934256776620111](https://jules.google.com/task/17386934256776620111) started by @dhruvhaldar*