### PR TITLE
🎨 Palette: Enhance StepperInput Web Accessibility with Explicit ARIA Value Attributes

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -23,3 +23,6 @@
 ## 2024-05-25 - Verify Conditional UI Elements in Verification Scripts
 **Learning:** When using Playwright to verify a UI element that only appears conditionally (e.g., a "Clear" button that appears only when an input is populated), the script must explicitly perform the prerequisite actions to trigger visibility before targeting the element.
 **Action:** Always mock or input prerequisite state (like using `fill` on an input via `page.get_by_placeholder`) in verification scripts before interacting with conditionally rendered UI components.
+## 2026-06-15 - Explicit ARIA Value Attributes for Web Spinbuttons
+**Learning:** React Native's `accessibilityValue` may not seamlessly translate to ARIA properties for web inputs functioning as a `spinbutton`, which can leave screen readers without critical context about min, max, and current values on web.
+**Action:** When building web-compatible spinbutton components in React Native, explicitly add `aria-valuemin`, `aria-valuemax`, and `aria-valuenow` to the underlying input component for robust screen reader compatibility.

--- a/components/StepperInput.tsx
+++ b/components/StepperInput.tsx
@@ -152,6 +152,11 @@ export const StepperInput = memo(function StepperInput({
         accessibilityRole="spinbutton"
         accessibilityValue={{ min, max, now: numericValue || 0 }}
         aria-labelledby={ariaLabelledBy}
+        {...(Platform.OS === 'web' ? {
+          'aria-valuemin': min,
+          'aria-valuemax': max,
+          'aria-valuenow': numericValue || 0
+        } : {})}
         selectTextOnFocus={true}
         returnKeyType="done"
         maxLength={3}


### PR DESCRIPTION
💡 What: Added `aria-valuemin`, `aria-valuemax`, and `aria-valuenow` properties to the `TextInput` component inside `StepperInput` exclusively for the web platform.
🎯 Why: React Native's `accessibilityValue` isn't fully translated to these critical ARIA properties on the web. Without them, web-based screen readers encountering a `spinbutton` cannot audibly communicate the input's current value, maximum bounds, or minimum bounds to visually impaired users.
♿ Accessibility: Fully resolves missing context for StepperInputs on the web, directly improving usability for users relying on assistive technologies. Recorded the underlying learning in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [3218633269457814206](https://jules.google.com/task/3218633269457814206) started by @dhruvhaldar*