### PR TITLE
🎨 Palette: Add accessibility label to history loading state

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -26,3 +26,6 @@
 ## 2026-06-15 - Explicit ARIA Value Attributes for Web Spinbuttons
 **Learning:** React Native's `accessibilityValue` may not seamlessly translate to ARIA properties for web inputs functioning as a `spinbutton`, which can leave screen readers without critical context about min, max, and current values on web.
 **Action:** When building web-compatible spinbutton components in React Native, explicitly add `aria-valuemin`, `aria-valuemax`, and `aria-valuenow` to the underlying input component for robust screen reader compatibility.
+## 2024-06-16 - Add ActivityIndicator Accessibility
+**Learning:** React Native's `ActivityIndicator` is visually obvious but completely silent to screen readers by default. When an entire section of UI (like a list of items) is replaced by an `ActivityIndicator`, screen reader users might think the app is frozen or empty because there's no verbal cue.
+**Action:** Always add `accessibilityRole="progressbar"` and a clear `accessibilityLabel` (e.g., "Loading data...") to standalone `ActivityIndicator` components that represent primary loading states.

--- a/app/(tabs)/history.tsx
+++ b/app/(tabs)/history.tsx
@@ -94,7 +94,13 @@ export default function TabTwoScreen() {
   // Optimization: Memoize empty state component to prevent re-mounting/re-rendering
   const emptyState = useMemo(() => (
     isLoading ? (
-       <ActivityIndicator size="large" color={textColor} style={{ marginTop: 20 }} />
+       <ActivityIndicator
+         size="large"
+         color={textColor}
+         style={{ marginTop: 20 }}
+         accessibilityLabel="Loading period history"
+         accessibilityRole="progressbar"
+       />
     ) : (
       <EmptyState
         title="No Entries Yet"


### PR DESCRIPTION
💡 What: Added an accessibility label and progressbar role to the loading ActivityIndicator in the History tab.
🎯 Why: Screen readers previously received no feedback when history was loading, which could lead to confusion for visually impaired users.
♿ Accessibility: The loading state is now correctly announced as a progress bar with descriptive text.

---
*PR created automatically by Jules for task [17282664992764029626](https://jules.google.com/task/17282664992764029626) started by @dhruvhaldar*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved screen reader support for loading indicators by adding proper accessibility labels and semantic roles to enhance compatibility with assistive technologies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->