### PR TITLE
🎨 Palette: Improve loading state accessibility in Insights screen

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2024-06-16 - Add ActivityIndicator Accessibility
 **Learning:** React Native's `ActivityIndicator` is visually obvious but completely silent to screen readers by default. When an entire section of UI (like a list of items) is replaced by an `ActivityIndicator`, screen reader users might think the app is frozen or empty because there's no verbal cue.
 **Action:** Always add `accessibilityRole="progressbar"` and a clear `accessibilityLabel` (e.g., "Loading data...") to standalone `ActivityIndicator` components that represent primary loading states.
+
+## 2026-06-17 - Add ActivityIndicator Accessibility
+**Learning:** React Native's `ActivityIndicator` is visually obvious but completely silent to screen readers by default. When an entire section of UI (like a list of items) is replaced by an `ActivityIndicator`, screen reader users might think the app is frozen or empty because there's no verbal cue.
+**Action:** Always add `accessibilityRole="progressbar"` and a clear `accessibilityLabel` (e.g., "Loading data...") to standalone `ActivityIndicator` components that represent primary loading states.

--- a/app/(tabs)/insights.tsx
+++ b/app/(tabs)/insights.tsx
@@ -197,7 +197,7 @@ export default function InsightsScreen() {
         <ThemedText type="title" style={[styles.title, { color: sectionHeadingtextColor }]}>Cycle Insights</ThemedText>
 
         {isLoading ? (
-          <ActivityIndicator size="large" color={barColor} style={{ marginTop: 50 }} />
+          <ActivityIndicator size="large" color={barColor} style={{ marginTop: 50 }} accessibilityRole="progressbar" accessibilityLabel="Loading cycle insights" />
         ) : (
           <>
             {/* Previous Cycles Section */}


### PR DESCRIPTION
🎨 Palette: Added Accessibility to Loading State

**💡 What:** 
Added `accessibilityRole="progressbar"` and `accessibilityLabel="Loading cycle insights"` to the primary `ActivityIndicator` in the Insights screen.

**🎯 Why:**
React Native's `ActivityIndicator` is visually obvious but completely silent to screen readers by default. When the Insights screen is loading data, the `ActivityIndicator` replaces the entire "Previous Cycles" section. Without accessibility props, screen reader users might think the app is frozen, broken, or completely empty because there is no verbal cue indicating a loading state.

**♿ Accessibility:**
- Added `accessibilityRole="progressbar"` to give the element the correct semantic meaning.
- Added `accessibilityLabel="Loading cycle insights"` to provide clear, contextual verbal feedback while the data is being fetched.

---
*PR created automatically by Jules for task [8673194785050866320](https://jules.google.com/task/8673194785050866320) started by @dhruvhaldar*