### PR TITLE
🎨 Palette: Add accessibility props to ActivityIndicator components

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -36,3 +36,6 @@
 ## 2024-06-18 - Add ActivityIndicator Accessibility
 **Learning:** React Native's `ActivityIndicator` is visually obvious but completely silent to screen readers by default. When an entire section of UI (like a list of items) is replaced by an `ActivityIndicator`, screen reader users might think the app is frozen or empty because there's no verbal cue.
 **Action:** Always add `accessibilityRole="progressbar"` and a clear `accessibilityLabel` (e.g., "Loading data...") to standalone `ActivityIndicator` components that represent primary loading states.
+## 2024-05-18 - Add ActivityIndicator Accessibility
+**Learning:** React Native's `ActivityIndicator` is visually obvious but completely silent to screen readers by default. When an entire section of UI (like a list of items) is replaced by an `ActivityIndicator`, or even within a button when the button text disappears, screen reader users might think the app is frozen or empty because there's no verbal cue.
+**Action:** Always add `accessibilityRole="progressbar"` and a clear `accessibilityLabel` (e.g., "Loading data...") to standalone `ActivityIndicator` components that represent primary loading states or inside buttons replacing their default content.

--- a/app/(tabs)/chatbot.tsx
+++ b/app/(tabs)/chatbot.tsx
@@ -137,7 +137,7 @@ export default function MenstruationScreen() {
             >
               {isDownloading ? (
                 <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
-                  <ActivityIndicator size="small" color="#FFFFFF" />
+                  <ActivityIndicator size="small" color="#FFFFFF" accessibilityRole="progressbar" accessibilityLabel="Downloading AI Model" />
                   <ThemedText style={styles.buttonText}>
                     Downloading... {Math.round(downloadProgress * 100)}%
                   </ThemedText>
@@ -174,7 +174,7 @@ export default function MenstruationScreen() {
             >
               {isInitializing ? (
                 <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
-                  <ActivityIndicator size="small" color="#FFFFFF" />
+                  <ActivityIndicator size="small" color="#FFFFFF" accessibilityRole="progressbar" accessibilityLabel="Loading AI Model" />
                   <ThemedText style={styles.buttonText}>Loading...</ThemedText>
                 </View>
               ) : (
@@ -221,7 +221,7 @@ export default function MenstruationScreen() {
                     accessibilityState={{ disabled: isSharing, busy: isSharing }}
                   >
                     {isSharing ? (
-                      <ActivityIndicator size="small" color={textColor} />
+                      <ActivityIndicator size="small" color={textColor} accessibilityRole="progressbar" accessibilityLabel="Sharing response" />
                     ) : (
                       <IconSymbol name="share" size={20} color={textColor} />
                     )}

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -520,7 +520,7 @@ export default function HomeScreen() {
             accessibilityState={{ disabled: isLogging || showSuccess, busy: isLogging }}
           >
             {isLogging ? (
-              <ActivityIndicator color="#ffffff" />
+              <ActivityIndicator color="#ffffff" accessibilityRole="progressbar" accessibilityLabel="Saving period entry" />
             ) : showSuccess ? (
               <ThemedText style={styles.logButtonText} accessibilityLiveRegion="polite">
                 Entry Logged! 🎉

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -412,7 +412,7 @@ export default function SettingsScreen() {
                             accessibilityState={{ busy: isImporting, disabled: isImporting }}
                         >
                             {isImporting ? (
-                                <ActivityIndicator color="#FFFFFF" style={{ marginRight: 8 }} />
+                                <ActivityIndicator color="#FFFFFF" style={{ marginRight: 8 }} accessibilityRole="progressbar" accessibilityLabel="Importing data" />
                             ) : (
                                 <IconSymbol name="square.and.arrow.down" size={20} color="#FFFFFF" style={{ marginRight: 8 }} />
                             )}
@@ -440,7 +440,7 @@ export default function SettingsScreen() {
                             accessibilityState={{ disabled: isImporting || isExporting, busy: isExporting }}
                         >
                             {isExporting ? (
-                                <ActivityIndicator color="#FFFFFF" style={{ marginRight: 8 }} />
+                                <ActivityIndicator color="#FFFFFF" style={{ marginRight: 8 }} accessibilityRole="progressbar" accessibilityLabel="Exporting data" />
                             ) : (
                                 <IconSymbol name="square.and.arrow.up" size={20} color="#FFFFFF" style={{ marginRight: 8 }} />
                             )}

--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -177,7 +177,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(({ onSubmit
             accessibilityRole="button"
             accessibilityState={{ disabled: isButtonDisabled, busy: isLoading }}
         >
-            {isLoading ? <ActivityIndicator color="#F1FAEE" /> : <ThemedText style={styles.buttonText}>Ask 🔍</ThemedText>}
+            {isLoading ? <ActivityIndicator color="#F1FAEE" accessibilityRole="progressbar" accessibilityLabel="Sending question" /> : <ThemedText style={styles.buttonText}>Ask 🔍</ThemedText>}
         </Pressable>
     </View>
   );


### PR DESCRIPTION
Added missing accessibility properties (`accessibilityRole="progressbar"` and `accessibilityLabel`) to `ActivityIndicator` components across several main UI elements including the Chatbot interaction screen, Settings screen, Home screen logging button, and the ChatInput component. This micro-improvement ensures that users utilizing screen readers are fully aware when loading, generating, importing, exporting, or sharing actions are in progress, mitigating potential confusion caused by visually apparent but otherwise silent loading states. Re-ran Jest to update the necessary snapshots.

---
*PR created automatically by Jules for task [2679457074964332968](https://jules.google.com/task/2679457074964332968) started by @dhruvhaldar*