### PR TITLE
🎨 Palette: Fix duplicate accessibility role on Settings switches

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -39,3 +39,6 @@
 ## 2024-05-18 - Add ActivityIndicator Accessibility
 **Learning:** React Native's `ActivityIndicator` is visually obvious but completely silent to screen readers by default. When an entire section of UI (like a list of items) is replaced by an `ActivityIndicator`, or even within a button when the button text disappears, screen reader users might think the app is frozen or empty because there's no verbal cue.
 **Action:** Always add `accessibilityRole="progressbar"` and a clear `accessibilityLabel` (e.g., "Loading data...") to standalone `ActivityIndicator` components that represent primary loading states or inside buttons replacing their default content.
+## 2026-06-25 - Prevent Duplicate Accessibility Roles in Compound Components
+**Learning:** When building compound interactive elements (like a setting row `Pressable` wrapping a `Switch`), React Native screen readers will double-announce roles and states if both the parent and child expose them.
+**Action:** Let the interactive parent handle focus and roles (e.g., `accessibilityRole="switch"`), and explicitly hide the purely visual inner component from screen readers using `importantForAccessibility="no-hide-descendants"` and `{...(Platform.OS === 'web' ? { tabIndex: -1, 'aria-hidden': true } : {})}`.

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -348,7 +348,9 @@ export default function SettingsScreen() {
                             onValueChange={handleLutealPhaseToggle}
                             accessibilityLabel="Luteal Phase Calculation"
                             accessible={false}
+                            importantForAccessibility="no-hide-descendants"
                             pointerEvents="none"
+                            {...(Platform.OS === 'web' ? { tabIndex: -1, 'aria-hidden': true } : {})}
                         />
                     </Pressable>
 
@@ -382,7 +384,9 @@ export default function SettingsScreen() {
                             onValueChange={handleScreenshotToggle}
                             accessibilityLabel="Prevent Screenshots"
                             accessible={false}
+                            importantForAccessibility="no-hide-descendants"
                             pointerEvents="none"
+                            {...(Platform.OS === 'web' ? { tabIndex: -1, 'aria-hidden': true } : {})}
                         />
                     </Pressable>
                 </View>


### PR DESCRIPTION
💡 What: The UX enhancement added
Fixed an accessibility issue where the `switch` role was being double-announced by screen readers on the Settings screen. This occurred because both the wrapper `Pressable` and the inner `Switch` component exposed the role/state. 

🎯 Why: The user problem it solves
Double-announcements create a confusing and overly verbose experience for screen reader users when navigating settings toggles.

📸 Before/After: Screenshots if visual change
No visual changes; purely structural semantic fix for assistive technology.

♿ Accessibility: Any a11y improvements made
By explicitly hiding the purely visual inner `Switch` from screen readers (`importantForAccessibility="no-hide-descendants"` for native, and `aria-hidden={true}` / `tabIndex={-1}` for web), focus and reading are correctly consolidated to the interactive parent row.

---
*PR created automatically by Jules for task [7548505940974763022](https://jules.google.com/task/7548505940974763022) started by @dhruvhaldar*