### PR TITLE
🎨 Palette: Add dynamic accessibility hints to async settings buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -42,3 +42,6 @@
 ## 2026-06-25 - Prevent Duplicate Accessibility Roles in Compound Components
 **Learning:** When building compound interactive elements (like a setting row `Pressable` wrapping a `Switch`), React Native screen readers will double-announce roles and states if both the parent and child expose them.
 **Action:** Let the interactive parent handle focus and roles (e.g., `accessibilityRole="switch"`), and explicitly hide the purely visual inner component from screen readers using `importantForAccessibility="no-hide-descendants"` and `{...(Platform.OS === 'web' ? { tabIndex: -1, 'aria-hidden': true } : {})}`.
+## 2024-06-25 - Never manually edit auto-generated Jest snapshot files
+**Learning:** Never manually edit auto-generated Jest snapshot files (e.g., `.snap` files), as manual modifications easily introduce mismatch formatting that causes CI test suites to fail. Always update snapshots programmatically by running `pnpm test -u` after making intentional changes to the underlying components.
+**Action:** Use `pnpm test -u` to update snapshots instead of editing them by hand.

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -412,7 +412,7 @@ export default function SettingsScreen() {
                             ]}
                             accessibilityRole="button"
                             accessibilityLabel="Import data from file"
-                            accessibilityHint="Restores your period history from a backup file"
+                            accessibilityHint={isImporting ? 'Please wait while data is being imported' : 'Restores your period history from a backup file'}
                             accessibilityState={{ busy: isImporting, disabled: isImporting }}
                         >
                             {isImporting ? (
@@ -440,7 +440,7 @@ export default function SettingsScreen() {
                             ]}
                             accessibilityRole="button"
                             accessibilityLabel="Export data to file"
-                            accessibilityHint="Creates a backup file of your period history"
+                            accessibilityHint={isExporting ? 'Please wait while data is being exported' : (isImporting ? 'Please wait while data is being imported' : 'Creates a backup file of your period history')}
                             accessibilityState={{ disabled: isImporting || isExporting, busy: isExporting }}
                         >
                             {isExporting ? (


### PR DESCRIPTION
## What
Added dynamic `accessibilityHint` properties to the "Import" and "Export" buttons in `app/(tabs)/settings.tsx`.

## Why
When performing asynchronous actions (like submitting or downloading), static accessibility hints do not explain why a button has become disabled or busy. Dynamically updating the `accessibilityHint` provides crucial context to screen reader users about the current state of the application.

## Accessibility
The `accessibilityHint` now explains "Please wait while data is being imported" or "Please wait while data is being exported", which enhances the already-present native announcements for `busy` and `disabled` states.

---
*PR created automatically by Jules for task [759462834491359135](https://jules.google.com/task/759462834491359135) started by @dhruvhaldar*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Updated the settings screen so import/export buttons announce more accurate, state-aware hints while actions are running.

* **Documentation**
  * Added guidance for contributors on handling auto-generated snapshot files and updating them through the test command after UI changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->