### PR TITLE
🎨 Palette: Group Form Controls with proper ARIA labels

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -45,3 +45,6 @@
 ## 2024-06-25 - Never manually edit auto-generated Jest snapshot files
 **Learning:** Never manually edit auto-generated Jest snapshot files (e.g., `.snap` files), as manual modifications easily introduce mismatch formatting that causes CI test suites to fail. Always update snapshots programmatically by running `pnpm test -u` after making intentional changes to the underlying components.
 **Action:** Use `pnpm test -u` to update snapshots instead of editing them by hand.
+## 2026-07-04 - Semantic Grouping for Form Controls
+**Learning:** When displaying a set of options (like radio buttons or checkboxes) in React Native, users of screen readers can lose context if the elements are not programmatically grouped together, as standard Views do not convey group boundaries.
+**Action:** Always wrap grouped form controls in a container with `accessibilityRole="radiogroup"` or `"group"`. Additionally, assign a `nativeID` to the group's visual title `Text` component and use the corresponding `aria-labelledby` property on the container to properly announce the group's context.

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -309,10 +309,10 @@ export default function HomeScreen() {
   // Optimized: Memoize flow section to prevent re-renders when notes/date change
   const flowSection = useMemo(() => (
     <ThemedView style={styles.section}>
-      <ThemedText type="subtitle" style={{ color: sectionHeadingtextColor, marginBottom: 10 }}>
+      <ThemedText nativeID="flow-group-label" type="subtitle" style={{ color: sectionHeadingtextColor, marginBottom: 10 }}>
         Period Flow 🩸
       </ThemedText>
-      <ThemedView style={styles.symptomsGrid}>
+      <ThemedView style={styles.symptomsGrid} accessibilityRole="radiogroup" aria-labelledby="flow-group-label">
         {flowTypes.map((flow) => (
           <SelectionButton
             key={flow}
@@ -332,10 +332,10 @@ export default function HomeScreen() {
   // Optimized: Memoize symptoms section
   const symptomsSection = useMemo(() => (
     <ThemedView style={styles.section}>
-      <ThemedText type="subtitle" style={{ color: sectionHeadingtextColor, marginBottom: 10 }}>
+      <ThemedText nativeID="symptoms-group-label" type="subtitle" style={{ color: sectionHeadingtextColor, marginBottom: 10 }}>
         Today's Symptoms 😟
       </ThemedText>
-      <ThemedView style={styles.symptomsGrid}>
+      <ThemedView style={styles.symptomsGrid} accessibilityRole="group" aria-labelledby="symptoms-group-label">
         {symptomsList.map((symptom) => (
           <SelectionButton
             key={symptom}


### PR DESCRIPTION
Added `nativeID` and `aria-labelledby` with the correct `accessibilityRole` on the Period Flow and Symptoms section to improve screen reader experience by properly identifying form control groups.

---
*PR created automatically by Jules for task [15689238612655578434](https://jules.google.com/task/15689238612655578434) started by @dhruvhaldar*