### PR TITLE
🎨 Palette: Add accessibilityHint to chatbot suggestion chips

### DIFF
--- a/app/(tabs)/chatbot.tsx
+++ b/app/(tabs)/chatbot.tsx
@@ -58,6 +58,7 @@ export default function MenstruationScreen() {
           ]}
           onPress={() => handleChat(q)}
           accessibilityLabel={`Ask: ${q}`}
+          accessibilityHint="Fills the chat input and sends this question to the AI assistant"
           accessibilityRole="button"
         >
           <ThemedText style={styles.suggestionText}>{q}</ThemedText>


### PR DESCRIPTION
💡 What: Added an `accessibilityHint` to the suggestion chips in the chatbot tab.
🎯 Why: Screen reader users now get clear, context-aware instructions explaining that tapping the chip will both fill the input and send the message to the AI.
♿ Accessibility: Improves UX for screen reader users by expanding on the primary action.

---
*PR created automatically by Jules for task [4139251594504225909](https://jules.google.com/task/4139251594504225909) started by @dhruvhaldar*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Added a hint to suggested-question chips so screen reader users know selecting one fills the chat input and sends the question to the assistant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->